### PR TITLE
Correct link to JIRA bug tracker.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -186,7 +186,7 @@ COMMANDBOX IMPORTANT LINKS
 Source Code
 - https://github.com/Ortus-Solutions/box-cli
 Tracker Site (Bug Tracking, Issues)
-- https://ortussolutions.atlassian.net/browse/BOX-CLI
+- https://ortussolutions.atlassian.net/browse/BOXCLI
 Documentation
 - http://wiki.coldbox.org
 Blog


### PR DESCRIPTION
Should link to BOXCLI, not BOX-CLI.
