### PR TITLE
Fixing issue with JRE Bundled Mac Distro

### DIFF
--- a/src/bin/box.sh
+++ b/src/bin/box.sh
@@ -73,7 +73,7 @@ then
 fi
 
 # Verify if we have an embedded version, if we do use that instead.
-JRE=$(dirname $this_script)/jre/bin
+JRE=$(dirname $this_script)/jre
 if [ -d "$JRE" ]
 then
 	java="$JRE/bin/java"


### PR DESCRIPTION
Fixing a minor bug causing the box script to look for the java
binary in a non-existent directory

COMMANDBOX-168