### PR TITLE
Handle Non JSON Response from Forgebox if Site is Unavailable

### DIFF
--- a/src/cfml/system/util/ForgeBox.cfc
+++ b/src/cfml/system/util/ForgeBox.cfc
@@ -232,7 +232,11 @@ or just add DEBUG to the root logger
 			results.message = HTTPResults.errorDetail;
 			if( len(HTTPResults.errorDetail) ){ results.error = true; }
 			// Try to inflate JSON
-			results.response = deserializeJSON(results.rawResponse,false);
+            if (isJSON(results.rawResponse)) {
+                results.response = deserializeJSON(results.rawResponse,false);
+            } else {
+                results.response = { messages = "Site Unreachable - ForgeBox API failed to return a JSON payload " };
+            }
 			
 			return results;
 		</cfscript>	


### PR DESCRIPTION
This gave a much nicer message to me when Forgebox couldn't be contacted to fetch coldbox from forgebox since coldbox site is down for me at the moment.