### PR TITLE
Development

### DIFF
--- a/src/cfml/commands/coldbox/create/orm-entity.cfc
+++ b/src/cfml/commands/coldbox/create/orm-entity.cfc
@@ -80,7 +80,7 @@ component extends='commandbox.system.BaseCommand' aliases='' excludeFromHelp=fal
 
 		// Read in Template
 		var modelContent 	 		= fileRead( '/commandbox/templates/orm/Entity#scriptPrefix#.txt' );
-		var modelTestContent 		= fileRead( '/commandbox/templates/testing/ModelBDDContent#scriptPrefix#.txt' );
+		var modelTestContent 		= fileRead( '/commandbox/templates/testing/ORMEntityBDDContent#scriptPrefix#.txt' );
 
 		// Basic replacements
 		modelContent 	= replaceNoCase( modelContent, '|entityName|', arguments.entityName, 'all' );

--- a/src/cfml/templates/testing/ORMEntityBDDContent.txt
+++ b/src/cfml/templates/testing/ORMEntityBDDContent.txt
@@ -1,0 +1,36 @@
+<!---
+The base orm entity test case will use the 'model' annotation as the instantiation path
+and then create it, prepare it for mocking and then place it in the variables scope as 'model'. It is your
+responsibility to update the model annotation instantiation path and init your model.
+--->
+<cfcomponent extends="coldbox.system.testing.BaseModelTest" model="|modelName|" output="false" hint="">
+	
+	<!--- *********************************** LIFE CYCLE Methods *********************************** --->
+
+	<cffunction name="beforeAll">
+		<!--- load ColdBox --->
+		<cfset this.loadColdbox = true>
+
+		<!--- setup the model --->
+		<cfset super.setup()>
+		
+		<!--- init the model object --->
+		<cfset model.init()>
+	</cffunction>
+
+	<cffunction name="afterAll">
+	
+	</cffunction>
+
+	<!--- *********************************** BDD SUITES *********************************** --->
+	
+	<cffunction name="run">
+		<cfscript>
+		describe( "|modelName| Suite", function(){
+			
+|TestCases|
+		});
+		</cfscript>
+	</cffunction>
+
+</cfcomponent>

--- a/src/cfml/templates/testing/ORMEntityBDDContentScript.txt
+++ b/src/cfml/templates/testing/ORMEntityBDDContentScript.txt
@@ -1,0 +1,35 @@
+/**
+* The base orm entity test case will use the 'model' annotation as the instantiation path
+* and then create it, prepare it for mocking and then place it in the variables scope as 'model'. It is your
+* responsibility to update the model annotation instantiation path and init your model.
+*/
+component extends="coldbox.system.testing.BaseModelTest" model="|modelName|"{
+	
+	/*********************************** LIFE CYCLE Methods ***********************************/
+
+	function beforeAll(){
+		// load ColdBox
+		this.loadColdbox = true;
+
+		// setup the model
+		super.setup();		
+		
+		// init the model object
+		model.init();
+	}
+
+	function afterAll(){
+	}
+
+	/*********************************** BDD SUITES ***********************************/
+	
+	function run(){
+
+		describe( "|modelName| Suite", function(){
+			
+|TestCases|
+		});
+
+	}
+
+}


### PR DESCRIPTION
Without these changes and the one I made to coldbox.system.testing.BaseModelTest.cfc (development branch pull request submitted), unit testing does not work on orm entities because they don't load ColdBox.  This is, in effect, a 'super.super.setup();' with loadColdbox set to true.