### PR TITLE
1.1.0 upgrade from 1.0.0 breaks embedded server

### DIFF
--- a/build/build.properties
+++ b/build/build.properties
@@ -6,7 +6,7 @@ commandbox.description=CommandBox is a ColdFusion (CFML) CLI, Package Manager, S
 
 #dependencies
 cfml.version=4.2.1.008
-cfml.loader.version=0.4.36
+cfml.loader.version=0.4.37
 cfml.cli.version=${cfml.loader.version}.${cfml.version}
 jre.version=1.8.0_40
 launch4j.version=3.4


### PR DESCRIPTION
should now delete any previous runwar jars when updating