### PR TITLE
COMMANDBOX-214: Lucee version leaves tons of old jars on upgrade

### DIFF
--- a/build/build.properties
+++ b/build/build.properties
@@ -6,9 +6,9 @@ commandbox.description=CommandBox is a ColdFusion (CFML) CLI, Package Manager, S
 
 #dependencies
 cfml.version=4.5.1.008
-cfml.loader.version=1.0.1
+cfml.loader.version=1.0.2
 cfml.cli.version=${cfml.loader.version}.${cfml.version}
-jre.version=1.8.0_40
+jre.version=1.8.0_45
 launch4j.version=3.4
 
 #build locations


### PR DESCRIPTION
Task-Url: https://ortussolutions.atlassian.net/browse/COMMANDBOX-214

Should now delete all jars in lib dir when updating.  Also updated JRE
to latest version.