### PR TITLE
fixes COMMANDBOX-220 and COMMANDBOX-221

### DIFF
--- a/build/build.properties
+++ b/build/build.properties
@@ -5,8 +5,8 @@ commandbox.supportURL=http://www.ortussolutions.com/services/support
 commandbox.description=CommandBox is a ColdFusion (CFML) CLI, Package Manager, Server and REPL
 
 #dependencies
-cfml.version=4.5.2.000
-cfml.loader.version=1.0.5
+cfml.version=4.5.2.005
+cfml.loader.version=1.0.6
 cfml.cli.version=${cfml.loader.version}.${cfml.version}
 jre.version=1.8.0_51
 launch4j.version=3.4

--- a/build/build.xml
+++ b/build/build.xml
@@ -161,7 +161,15 @@ External Dependencies:
         	<fileset dir="${src.dir}/resources" />
         </copy>
         <copy file="${src.dir}/resources/cli.properties" todir="${temp.dir}/rcli/cliloader" overwrite="true" encoding="UTF-8"/>
-        
+        <!--  set default password -->
+        <unzip src="${temp.dir}/rcli/engine.zip" dest="${temp.dir}/engine" overwrite="true"/>
+        <lucee-password 
+          server-password="commandbox" config-server-file="${temp.dir}/engine/cfml/cli/cfml-server/context/lucee-server.xml"
+          web-password="commandbox" config-web-file="${temp.dir}/engine/cfml/cli/cfml-web/lucee-web.xml.cfm"
+        />
+        <zip destfile="${temp.dir}/rcli/engine.zip" update="false" level="9">
+          <zipfileset dir="${temp.dir}/engine" />
+        </zip>
         <!-- jar up the cli again -->
         <zip destfile="${dist.dir}/box.jar" update="false" level="9">
         	<zipfileset dir="${temp.dir}/rcli" />


### PR DESCRIPTION
The underlying password encryption library needs to be updated for the latest Lucee passwords with salts, so this doesn't fix COMMANDBOX-222 yet, but it shouldn't throw an error while building, theoretically.

No need to merge this in really, but you can test that the other two issues are fixed by this bump to the loader and lucee versions.

Really you can test by just updating the build.properties to reflect what's in this pull.