### PR TITLE
Add ability for server config key in box.json

### DIFF
--- a/src/cfml/commands/server/start.cfc
+++ b/src/cfml/commands/server/start.cfc
@@ -89,6 +89,16 @@ component extends="commandbox.system.BaseCommand" aliases="start" excludeFromHel
 		// Get package descriptor for overrides
 		var boxJSON = packageService.readPackageDescriptor( serverInfo.webroot );
 
+		// server config structure
+		if(structKeyExists(boxJSON,'server')){
+			var serverConfig = boxJSON.server;
+			for (var configKey in serverConfig){
+				if(structKeyExists(arguments,configKey)){
+					arguments[configKey]=serverConfig[configKey];
+				}
+			}
+		}
+
 		// Update data from arguments
 		serverInfo.debug 	= arguments.debug;
 		serverInfo.name 	= arguments.name is "" ? listLast( serverInfo.webroot, "\/" ) : arguments.name;


### PR DESCRIPTION
If a server key is detected in box.json, `box start` will override the default arguments with those settings.  

e.g.: 

```
{
    "dependencies":{
        "logbox":"2.0.0",
        "testbox":"2.1.0",
        "relax":"2.1.0",
        "cbi18n":"1.0.2",
        "cbvalidation":"1.0.3",
        "cbmessagebox":"1.0.0",
        "cbstorages":"1.0.0",
        "cbcompat":"1.1.0.0000",
        "cbmailservices":"1.0.0",
        "cbsecurity":"1.1.0",
        "wikitext":"1.1.0",
        "coldbox":"4.1.0+00002",
        "cborm":"1.0.3"
    },
    "installPaths":{
        "logbox":"logbox",
        "testbox":"testbox",
        "relax":"modules/relax",
        "cbi18n":"modules/cbi18n",
        "cbvalidation":"modules/cbvalidation",
        "cbmessagebox":"modules/cbmessagebox",
        "cbstorages":"modules/cbstorages",
        "coldbox-be":"coldbox",
        "cbcompat":"modules/cbcompat",
        "cbmailservices":"modules/cbmailservices",
        "cbsecurity":"modules/cbsecurity",
        "wikitext":"modules/wikitext",
        "coldbox":"coldbox",
        "cborm":"modules/cborm"
    },
    "server":{
        "port":57170,
        "heapSize":1024,
        "rewritesEnable":true
    },
    "testbox":{
        "runner":"http://127.0.0.1:57170/tests/runner.cfm"
    }
}
```