### PR TITLE
COMMANDBOX-204: Use pwd as initial directory for REPL

### DIFF
--- a/src/cfml/system/commands/repl.cfc
+++ b/src/cfml/system/commands/repl.cfc
@@ -39,10 +39,11 @@ component extends="commandbox.system.BaseCommand" aliases="" excludeFromHelp=fal
 	/**
 	* @input.hint Optional CFML to execute. If provided, the command exits immediatley.
 	* @script.hint Run REPL in script or tag mode
+	* @directory.hint Directory to start the REPL in (defaults to current working directory).
 	**/
 	function run( string input,  boolean script=true, string directory = getCWD() ){
 		
-		var quit 	 		= false;
+		var quit 	 	= false;
 		var results  		= "";
 		var executor 		= wirebox.getInstance( "executor" );
 		var newHistory 		= arguments.script ? variables.REPLScriptHistoryFile : variables.REPLTagHistoryFile;

--- a/src/cfml/system/commands/repl.cfc
+++ b/src/cfml/system/commands/repl.cfc
@@ -33,10 +33,6 @@ component extends="commandbox.system.BaseCommand" aliases="" excludeFromHelp=fal
 	function init(){
 		super.init();
 
-		// setup tmp include directories
-		variables.tmpDirRelative = "/commandbox/system/tmp";
-		variables.tmpDirAbsolute = expandPath( "/commandbox/system/tmp" );
-
 		return this;
 	}
 
@@ -44,12 +40,16 @@ component extends="commandbox.system.BaseCommand" aliases="" excludeFromHelp=fal
 	* @input.hint Optional CFML to execute. If provided, the command exits immediatley.
 	* @script.hint Run REPL in script or tag mode
 	**/
-	function run( string input,  boolean script=true ){
+	function run( string input,  boolean script=true, string directory = getCWD() ){
 		
 		var quit 	 		= false;
 		var results  		= "";
 		var executor 		= wirebox.getInstance( "executor" );
 		var newHistory 		= arguments.script ? variables.REPLScriptHistoryFile : variables.REPLTagHistoryFile;
+		
+		// setup tmp include directories
+		variables.tmpDirRelative = arguments.directory;
+		variables.tmpDirAbsolute = expandPath( arguments.directory );
 
 		// Setup REPL history file
 		shell.getReader().setHistory( newHistory );


### PR DESCRIPTION
Instead of using the CommandBox tmp directory, use the present working directory (pwd) to allow for easier instantiation of components in the current project.

This pull request (potentially) introduces a breaking change, as the base directory for all REPL commands is now different.