### PR TITLE
COMMANDBOX-112: Allow path/package in name argument

### DIFF
--- a/src/cfml/commands/testbox/create/bdd.cfc
+++ b/src/cfml/commands/testbox/create/bdd.cfc
@@ -15,6 +15,19 @@ component extends="commandbox.system.BaseCommand" aliases="" excludeFromHelp=fal
 	* @directory.hint The base directory to create your BDD spec in and creates the directory if it does not exist.
 	 **/
 	function run( required name, boolean open=false, directory=getCWD() ){
+		// Allow dot-delimited paths
+		arguments.name = replace( arguments.name, '.', '/', 'all' );
+		
+		// Check if the name is actually a path
+		var nameArray = arguments.name.listToArray( '/' );
+		var nameArrayLength = nameArray.len();
+		if (nameArrayLength > 1) {
+			// If it is a path, split the path from the name
+			arguments.name = nameArray[nameArrayLength];
+			var extendedPath = nameArray.slice(1, nameArrayLength - 1).toList('/');
+			arguments.directory &= '/#extendedPath#';
+		}
+		
 		// This will make each directory canonical and absolute		
 		arguments.directory = fileSystemUtil.resolvePath( arguments.directory );
 						
@@ -22,9 +35,6 @@ component extends="commandbox.system.BaseCommand" aliases="" excludeFromHelp=fal
 		if( !directoryExists( arguments.directory ) ) {
 			directoryCreate( arguments.directory );			
 		}
-		
-		// Allow dot-delimited paths
-		arguments.name = replace( arguments.name, '.', '/', 'all' );
 		
 		// This help readability so the success messages aren't up against the previous command line
 		print.line();

--- a/src/cfml/commands/testbox/create/unit.cfc
+++ b/src/cfml/commands/testbox/create/unit.cfc
@@ -15,6 +15,19 @@ component extends="commandbox.system.BaseCommand" aliases="" excludeFromHelp=fal
 	* @directory.hint The base directory to create your CFC in and creates the directory if it does not exist.
 	 **/
 	function run( required name, boolean open=false, directory=getCWD() ){
+		// Allow dot-delimited paths
+		arguments.name = replace( arguments.name, '.', '/', 'all' );
+		
+		// Check if the name is actually a path
+		var nameArray = arguments.name.listToArray( '/' );
+		var nameArrayLength = nameArray.len();
+		if (nameArrayLength > 1) {
+			// If it is a path, split the path from the name
+			arguments.name = nameArray[nameArrayLength];
+			var extendedPath = nameArray.slice(1, nameArrayLength - 1).toList('/');
+			arguments.directory &= '/#extendedPath#';
+		}
+		
 		// This will make each directory canonical and absolute		
 		arguments.directory = fileSystemUtil.resolvePath( arguments.directory );
 						
@@ -22,9 +35,6 @@ component extends="commandbox.system.BaseCommand" aliases="" excludeFromHelp=fal
 		if( !directoryExists( arguments.directory ) ) {
 			directoryCreate( arguments.directory );			
 		}
-		
-		// Allow dot-delimited paths
-		arguments.name = replace( arguments.name, '.', '/', 'all' );
 		
 		// This help readability so the success messages aren't up against the previous command line
 		print.line();


### PR DESCRIPTION
When creating tests using the `testbox create bdd` or `testbox create unit`, the directory check fails to create the needed directories when the directories were actually in the `name` argument (like `foo.bar.test` or `foo/bar/test`).

This pull requests fixes the bug by checking if these are multiple pieces in the name and extracting the name and appending the directory as needed.  The original use case of `testbox create bdd test` still works as normal.