### PR TITLE
bumped JRE and RunWar versions, downgraded Lucee to latest stable

### DIFF
--- a/build/build.properties
+++ b/build/build.properties
@@ -11,10 +11,10 @@ java.pack200=false
 
 #dependencies
 dependencies.dir=${basedir}/lib
-cfml.version=4.5.1.023
+cfml.version=4.5.2.016
 cfml.loader.version=1.0.7
 cfml.cli.version=${cfml.loader.version}.${cfml.version}
-lucee.version=4.5.1.023
+lucee.version=4.5.2.016
 jre.version=1.8.0_60
 launch4j.version=3.4
 runwar.version=3.2.0

--- a/build/build.properties
+++ b/build/build.properties
@@ -11,13 +11,13 @@ java.pack200=false
 
 #dependencies
 dependencies.dir=${basedir}/lib
-cfml.version=4.5.2.005
+cfml.version=4.5.1.023
 cfml.loader.version=1.0.7
 cfml.cli.version=${cfml.loader.version}.${cfml.version}
-lucee.version=4.5.2.005
-jre.version=1.8.0_51
+lucee.version=4.5.1.023
+jre.version=1.8.0_60
 launch4j.version=3.4
-runwar.version=3.1.0
+runwar.version=3.2.0
 
 #build locations
 build.type=localdev


### PR DESCRIPTION
Does what it says on the tin.  :)

The RunWar update brings Undertow 1.3.0.Final, in which they were nice enough to add a feature I requested: allowing custom status response messages!  This is mainly for Taffy or other REST frameworks, as a couple users said they needed it to be able to run their applications.

This downgrades Lucee to the latest 4.5.1 stable, although we could also upgrade to the latest dev-- I'm a bit torn, as there are some nice bug fixes in the latest 4.5.2 version.