### PR TITLE
Restore !directory & !file

### DIFF
--- a/src/cfml/system/config/urlrewrite.xml
+++ b/src/cfml/system/config/urlrewrite.xml
@@ -11,10 +11,8 @@
 		<note>Generic Front-Controller URLs</note>
 		<condition type="request-uri" operator="notequal">/(index.cfm|robots.txt|osd.xml|flex2gateway|cfide|cfformgateway|tests|railo-context|lucee|admin-context|modules/contentbox-dsncreator|modules/contentbox-installer|modules/contentbox|files|images|js|javascripts|css|styles|config).*</condition>
 		<condition type="request-uri" operator="notequal">\.(bmp|gif|jpe?g|png|css|js|txt|xlsx?|docx?|ico|swf|woff2?|ttf|otf)$</condition>
-		<!-- For some reason this is not working now.
 		<condition type="request-filename" operator="notdir"/>
 		<condition type="request-filename" operator="notfile"/>
-		-->
 		<from>^/(.+)$</from>
 		<to type="passthrough">/index.cfm/$1</to>
 	</rule>


### PR DESCRIPTION
These appear to be working fine now in the latest version of Commandbox/Lucee.  It would be nice to have have these back in place by default to be able use Coldbox extension detection and static files with those same extensions.