### PR TITLE
Use pwd for `run` command

### DIFF
--- a/src/cfml/system/modules/system-commands/commands/run.cfc
+++ b/src/cfml/system/modules/system-commands/commands/run.cfc
@@ -52,11 +52,14 @@ component{
             var pwd = fileSystemUtil.resolvePath( '.' );
             var CWD = createObject( 'java', 'java.io.File' ).init( pwd );
 
-			// execute the server command
-            var IOUtil = createObject( 'java', 'lucee.commons.io.IOUtil' );
-            var charset = createObject( 'java', 'lucee.commons.io.SystemUtil' ).getCharSet();
-            var process = createObject( 'java', 'java.lang.Runtime' ).getRuntime().exec( '#arguments.name# #arguments.args#', [], CWD );
-            var executeResult = IOUtil.toString( process.getInputStream(), charset );
+            // execute the server command
+            var process = createObject( 'java', 'java.lang.Runtime' )
+                .getRuntime()
+                .exec( '#arguments.name# #arguments.args#', [], CWD );
+            var commandResult = createObject( 'java', 'lucee.commons.cli.Command' )
+                .execute( process );
+            var executeResult = commandResult.getOutput();
+            var executeError = commandResult.getError();
 
 			// Output Results
 			if( !isNull( executeResult ) && len( executeResult ) ) {

--- a/src/cfml/system/modules/system-commands/commands/run.cfc
+++ b/src/cfml/system/modules/system-commands/commands/run.cfc
@@ -48,19 +48,27 @@ component{
 		var executeError 	= "";
 
 		try{
+            // grab the current working directory
+            var pwd = fileSystemUtil.resolvePath( '.' );
+            var CWD = createObject( 'java', 'java.io.File' ).init( pwd );
+
 			// execute the server command
-			execute name="#arguments.name#" arguments="#arguments.args#" timeout="#arguments.timeout#" variable="executeResult" errorvariable="executeError";
+            var IOUtil = createObject( 'java', 'lucee.commons.io.IOUtil' );
+            var charset = createObject( 'java', 'lucee.commons.io.SystemUtil' ).getCharSet();
+            var process = createObject( 'java', 'java.lang.Runtime' ).getRuntime().exec( '#arguments.name# #arguments.args#', [], CWD );
+            var executeResult = IOUtil.toString( process.getInputStream(), charset );
+
 			// Output Results
 			if( !isNull( executeResult ) && len( executeResult ) ) {
-				print.cyanLine( executeResult );				
+				print.cyanLine( executeResult );
 			}
 			// Output error
 			if( !isNull( executeError ) &&  len( executeError ) ) {
-				print.redLine( executeError );				
+				print.redLine( executeError );
 			}
-			
+
 			print.greenLine( "Command completed succesfully!" );
-		
+
 		} catch (any e) {
 			error( '#e.message##CR##e.detail#' );
 		}


### PR DESCRIPTION
Based off of a Slack conversation with Brad, this uses the Java Runtime process to run the shell commands in CommandBox's current working directory.

This allows commands like `subl .` or `atom .` to open CommandBox's current working directory instead of the directory where CommandBox was started.