### PR TITLE
Create needed directories when creating a view

### DIFF
--- a/src/cfml/system/modules/coldbox-commands/commands/coldbox/create/view.cfc
+++ b/src/cfml/system/modules/coldbox-commands/commands/coldbox/create/view.cfc
@@ -1,52 +1,65 @@
 /**
 * Create a new view in an existing ColdBox application.  Run this command in the root
-* of your app for it to find the correct folder.  By default, your new view will be created in /views but you can 
+* of your app for it to find the correct folder.  By default, your new view will be created in /views but you can
 * override that with the directory param.
 * .
 * {code:bash}
 * coldbox create view myView
 * {code}
-*  
+*
 **/
 component {
-	
+
 	/**
 	* @name.hint Name of the view to create without the .cfm.
 	* @helper.hint Generate a helper file for this view
 	* @directory.hint The base directory to create your view in and creates the directory if it does not exist.
 	 **/
-	function run( 	
+	function run(
 		required name,
 		boolean helper=false,
-		directory='views' 
+		directory='views'
 	){
-		// This will make each directory canonical and absolute		
+        // Allow dot-delimited paths
+		arguments.name = replace( arguments.name, '.', '/', 'all' );
+
+		// Check if the name is actually a path
+		var nameArray = arguments.name.listToArray( '/' );
+		var nameArrayLength = nameArray.len();
+		if (nameArrayLength > 1) {
+			// If it is a path, split the path from the name
+			arguments.name = nameArray[nameArrayLength];
+			var extendedPath = nameArray.slice(1, nameArrayLength - 1).toList('/');
+			arguments.directory &= '/#extendedPath#';
+		}
+        
+		// This will make each directory canonical and absolute
 		arguments.directory = fileSystemUtil.resolvePath( arguments.directory );
-						
+
 		// Validate directory
 		if( !directoryExists( arguments.directory ) ) {
-			directoryCreate( arguments.directory );			
+			directoryCreate( arguments.directory );
 		}
-		
+
 		// This help readability so the success messages aren't up against the previous command line
 		print.line();
-		
+
 		var viewContent = '<h1>#arguments.name# view</h1>';
 		var viewHelperContent = '<!--- #arguments.name# view Helper --->';
-		
+
 		// Write out view
-		var viewPath = '#arguments.directory#/#arguments.name#.cfm'; 
+		var viewPath = '#arguments.directory#/#arguments.name#.cfm';
 		file action='write' file='#viewPath#' mode ='777' output='#viewContent#';
-		print.greenLine( 'Created #viewPath#' );				
-		
+		print.greenLine( 'Created #viewPath#' );
+
 		if( arguments.helper ) {
 			// Write out view helper
-			var viewHelperPath = '#arguments.directory#/#arguments.name#Helper.cfm'; 
+			var viewHelperPath = '#arguments.directory#/#arguments.name#Helper.cfm';
 			file action='write' file='#viewHelperPath#' mode ='777' output='#viewHelperContent#';
 			print.greenLine( 'Created #viewHelperPath#' );
-			
+
 		}
-	
+
 	}
 
 }


### PR DESCRIPTION
Like other create functions like `coldbox create bdd`, do the following:

1) Automatically create any missing folders based on the `name` passed
2) Allow dot-delimited paths in the `name`