### PR TITLE
COMMANDBOX-360 Fix for double equals sign breaking nix shell script

### DIFF
--- a/src/bin/box.sh
+++ b/src/bin/box.sh
@@ -27,7 +27,7 @@ then
 fi
 
 # Prepare Java arguments
-java_args=="$BOX_JAVA_ARGS -client"
+java_args="$BOX_JAVA_ARGS -client"
 
 ##############################################################################
 ##  OS SPECIFIC CLEANUP + ARGS


### PR DESCRIPTION
Tested on both a fedora and ubuntu based Linux distribution. The change to this file that introduced `JAVA_ARGS==...` broke the script in Linux. Using a single equals sign fixes the problem.