### PR TITLE
COMMANDBOX-361 Fixing permissions on box executable for linux distro …

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -437,7 +437,7 @@ External Dependencies:
           <fileset file="${dist.dir}/box.jar" />
         </concat>
         <!-- Change execute perm -->
-        <chmod file="${dist.dir}/box" perm="a+x"/>
+        <chmod file="${dist.dir}/box" perm="755"/>
         <!-- Create distro zip -->
 		<zip destfile="${dist.dir}/${distro.name}-bin-${commandbox.version}.zip" level="9" update="false">
 	        <zipfileset file="${dist.dir}/box" filemode="711" prefix="" />


### PR DESCRIPTION
…users to be able to execute the file without sudo (these are the normal permissions used for /usr/bin/* binaries