### PR TITLE
Increase RunWAR startup timeout for Adobe engines

### DIFF
--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -530,7 +530,7 @@ component accessors="true" singleton {
 
 	var startupTimeout = 120;
 	// Increase our startup allowance for Adobe engines, since a number of files are generated on the first request
-	if( CFEngineName == 'adobe' ) {
+	if( CFEngineName == 'adobe' ){
 		startupTimeout=240;
 	}
 							

--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -530,7 +530,9 @@ component accessors="true" singleton {
 
 	var startupTimeout = 120;
 	// Increase our startup allowance for Adobe engines, since a number of files are generated on the first request
-	if( CFEngineName == 'adobe' ) startupTimeout=240;
+	if( CFEngineName == 'adobe' ) {
+		startupTimeout=240;
+	}
 							
 	// The java arguments to execute:  Shared server, custom web configs
 	var args = ' #serverInfo.JVMargs# -Xmx#serverInfo.heapSize#m -Xms#serverInfo.heapSize#m'

--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -526,6 +526,11 @@ component accessors="true" singleton {
 	// Serialize tray options and write to temp file
 	var trayOptionsPath = serverInfo.serverHome & '/trayOptions.json';
 	fileWrite( trayOptionsPath,  serializeJSON( serverInfo.trayOptions ) );
+
+
+	var startupTimeout = 120;
+	// Increase our startup allowance for Adobe engines, since a number of files are generated on the first request
+	if( CFEngineName == 'adobe' ) startupTimeout=240;
 							
 	// The java arguments to execute:  Shared server, custom web configs
 	var args = ' #serverInfo.JVMargs# -Xmx#serverInfo.heapSize#m -Xms#serverInfo.heapSize#m'
@@ -539,7 +544,7 @@ component accessors="true" singleton {
 			& ' --tray-icon "#serverInfo.trayIcon#" --tray-config "#trayOptionsPath#"'
 			& ' --directoryindex "#serverInfo.directoryBrowsing#" --cfml-web-config "#serverInfo.webConfigDir#"'
 			& ( len( CLIAliases ) ? ' --dirs "#CLIAliases#"' : '' )
-			& ' --cfml-server-config "#serverInfo.serverConfigDir#" #serverInfo.runwarArgs# --timeout 120';
+			& ' --cfml-server-config "#serverInfo.serverConfigDir#" #serverInfo.runwarArgs# --timeout #startupTimeout#';
 			
 	// Starting a WAR
 	if (serverInfo.WARPath != "" ) {


### PR DESCRIPTION
Since ACF performs a number of i/o-intensive operations on the first startup of a server, this PR doubles the startup timeout for Adobe engines.  When these write operations are performed on network attached storage, this can lead to timeouts.

See this Travis build for a use case example:  https://travis-ci.org/jclausen/cbox-i18n/builds/163429901