### PR TITLE
remove version numbers...

### DIFF
--- a/build/brew-template.rb
+++ b/build/brew-template.rb
@@ -3,12 +3,10 @@ class Commandbox < Formula
   homepage "https://www.ortussolutions.com/products/commandbox"
   url "@repoPRDURL@/ortussolutions/commandbox/@stable-version@/commandbox-bin-@stable-version@.zip"
   sha256 "@stable-sha256@"
-  version "@stable-version@"
 
   devel do
     url "@repoURL@/ortussolutions/commandbox/@version@/commandbox-bin-@version@.zip?build=@buildnumber@"
     sha256 "@sha256@"
-    version "@version@"
   end
 
   bottle :unneeded


### PR DESCRIPTION
 since Homebrew now looks for them in URL

See: https://bot.brew.sh/job/Homebrew%20Core/9086/