### PR TITLE
fix paths in flex-config.xml

### DIFF
--- a/src/cfml/system/services/ServerEngineService.cfc
+++ b/src/cfml/system/services/ServerEngineService.cfc
@@ -63,10 +63,8 @@ component accessors="true" singleton="true" {
 				flexConfig = replace(flexConfig, "/WEB-INF/", installDetails.installDir & "/WEB-INF/","all");
  -				fileWrite(installDetails.installDir & "/WEB-INF/cfform/flex-config.xml", flexConfig);
 			} else { 
-				// Remove this ELSE block in a future revision. 
+				// TODO: Remove this ELSE block in a future revision. 
 				// This will fix the flex-config.xml files that have been corrupted because we weren't checking initialInstall, above.  
-				
-				// escape back slashes,forward slashes, periods and colons in the installDir for the regular expression
 				var escapedInstDir=reReplace(installDetails.installDir,"(\\|\/|\.|\:)","\\1","all");
 				//reReplace supports 5 backreferences in the replacement substring for case conversions. It doesn't allow escaping of these backreferences though in case you want them literally! 
 				var replaceString=reReplace(installDetails.installDir,"\\(u|U|l|L|E)","##chr(92)##\1","all");

--- a/src/cfml/system/services/ServerEngineService.cfc
+++ b/src/cfml/system/services/ServerEngineService.cfc
@@ -57,8 +57,13 @@ component accessors="true" singleton="true" {
 		// set flex log dir to prevent WEB-INF/cfform being created in project dir
 		if (fileExists(installDetails.installDir & "/WEB-INF/cfform/flex-config.xml")) {
 			var flexConfig = fileRead(installDetails.installDir & "/WEB-INF/cfform/flex-config.xml");
-			flexConfig = replace(flexConfig, "/WEB-INF/", installDetails.installDir & "/WEB-INF/","all");
-			fileWrite(installDetails.installDir & "/WEB-INF/cfform/flex-config.xml", flexConfig);
+			// escape back slashes,forward slashes, periods and colons in the installDir for the regular expression
+			var escapedInstDir=reReplace(installDetails.installDir,"(\\|\/|\.|\:)","\\1","all");
+			//ugh. reReplace supports 5 backreferences in the replacement substring for case conversions. It doesn't allow escaping of these backreferences though in case you want them literally! 
+			var replaceString=reReplace(installDetails.installDir,"\\(u|U|l|L|E)","##chr(92)##\1","all");
+			var regex="(?:" & escapedInstDir & ")*" & "\/WEB-INF\/" ;
+			flexConfig = reReplace(flexConfig, regex, replaceString & "/WEB-INF/","all");
+			fileWrite(installDetails.installDir & "/WEB-INF/cfform/flex-config.xml", evaluate(de(flexConfig)));
 		}
 		return installDetails;
 	}

--- a/src/cfml/system/services/ServerEngineService.cfc
+++ b/src/cfml/system/services/ServerEngineService.cfc
@@ -50,20 +50,30 @@ component accessors="true" singleton="true" {
 	* @version Version number or empty to use default
 	**/
 	public function installAdobe( required destination, required version ) {
-		var installDetails = installEngineArchive( 'adobe@#version#', destination );			
+		var installDetails = installEngineArchive( 'adobe@#version#', destination );	
+
 		// set password to "commandbox"
 		// TODO: Just make this changes directly in the WAR files
 		fileWrite( installDetails.installDir & "/WEB-INF/cfusion/lib/password.properties", "rdspassword=#cr#password=commandbox#cr#encrypted=false" );
 		// set flex log dir to prevent WEB-INF/cfform being created in project dir
 		if (fileExists(installDetails.installDir & "/WEB-INF/cfform/flex-config.xml")) {
 			var flexConfig = fileRead(installDetails.installDir & "/WEB-INF/cfform/flex-config.xml");
-			// escape back slashes,forward slashes, periods and colons in the installDir for the regular expression
-			var escapedInstDir=reReplace(installDetails.installDir,"(\\|\/|\.|\:)","\\1","all");
-			//ugh. reReplace supports 5 backreferences in the replacement substring for case conversions. It doesn't allow escaping of these backreferences though in case you want them literally! 
-			var replaceString=reReplace(installDetails.installDir,"\\(u|U|l|L|E)","##chr(92)##\1","all");
-			var regex="(?:" & escapedInstDir & ")*" & "\/WEB-INF\/" ;
-			flexConfig = reReplace(flexConfig, regex, replaceString & "/WEB-INF/","all");
-			fileWrite(installDetails.installDir & "/WEB-INF/cfform/flex-config.xml", evaluate(de(flexConfig)));
+
+			if(!installDetails.internal && installDetails.initialInstall ) {
+				flexConfig = replace(flexConfig, "/WEB-INF/", installDetails.installDir & "/WEB-INF/","all");
+ -				fileWrite(installDetails.installDir & "/WEB-INF/cfform/flex-config.xml", flexConfig);
+			} else { 
+				// Remove this ELSE block in a future revision. 
+				// This will fix the flex-config.xml files that have been corrupted because we weren't checking initialInstall, above.  
+				
+				// escape back slashes,forward slashes, periods and colons in the installDir for the regular expression
+				var escapedInstDir=reReplace(installDetails.installDir,"(\\|\/|\.|\:)","\\1","all");
+				//reReplace supports 5 backreferences in the replacement substring for case conversions. It doesn't allow escaping of these backreferences though in case you want them literally! 
+				var replaceString=reReplace(installDetails.installDir,"\\(u|U|l|L|E)","##chr(92)##\1","all");
+				var regex="(?:" & escapedInstDir & ")*" & "\/WEB-INF\/" ;
+				flexConfig = reReplace(flexConfig, regex, replaceString & "/WEB-INF/","all");
+				fileWrite(installDetails.installDir & "/WEB-INF/cfform/flex-config.xml", evaluate(de(flexConfig)));
+			}
 		}
 		return installDetails;
 	}


### PR DESCRIPTION
This will correct the paths in the flex-config.xml file that were invalid due to a bug that re-appended part of the path on every server start. (server still starts fine,  but paths in this file keep growing and growing)   

So when your flex-config.xml has stuff like this:
`<global-css-url>C:\Users\user\.CommandBox/server/F072138B9E86DC43FD4DC1C70F3B5CAF-myviawest/adobe-10.0.21.300068C:\Users\user\.CommandBox/server/F072138B9E86DC43FD4DC1C70F3B5CAF-myviawest/adobe-10.0.21.300068C:\Users\user\.CommandBox/server/F072138B9E86DC43FD4DC1C70F3B5CAF-myviawest/adobe-10.0.21.300068C:\Users\user\.CommandBox/server/F072138B9E86DC43FD4DC1C70F3B5CAF-myviawest/adobe-10.0.21.300068</global-css-url>`

upon server start, it will be updated to a valid path, like: 
`<global-css-url>C:\Users\user\.CommandBox/server/F072138B9E86DC43FD4DC1C70F3B5CAF-myviawest/adobe-10.0.21.300068/WEB-INF/cfform/global.css</global-css-url>`

There are several places in the flex-config.xml file where paths were getting corrupt.  This corrects them all.  

Note: I ran into a possible bug with reReplace() that causes backreferences in the substring for changing case (like, \U, \u, \L,\l) to be inescapable.  I had to use a "creative" solution to allow these backrefs to be evaluated literally.   See my topic on google groups about the issue and how to reproduce it in commandbox repl.   

 