### PR TITLE
Whitespace/formatting police

### DIFF
--- a/src/cfml/system/modules_app/coldbox-commands/templates/ActionContentScript.txt
+++ b/src/cfml/system/modules_app/coldbox-commands/templates/ActionContentScript.txt
@@ -1,6 +1,6 @@
 	/**
-    * |action|  
-    */
-    function |action|( event, rc, prc ){
+	* |action|
+	*/
+	function |action|( event, rc, prc ){
 		event.setView( "|Name|/|action|" );
-	}	
+	}

--- a/src/cfml/system/modules_app/coldbox-commands/templates/HandlerContentScript.txt
+++ b/src/cfml/system/modules_app/coldbox-commands/templates/HandlerContentScript.txt
@@ -9,7 +9,7 @@ component{
 	this.posthandler_only 	= "";
 	this.posthandler_except = "";
 	this.aroundHandler_only = "";
-	this.aroundHandler_except = "";		
+	this.aroundHandler_except = "";
 	// REST Allowed HTTP Methods Ex: this.allowedMethods = {delete='POST,DELETE',index='GET'}
 	this.allowedMethods = {};
 	

--- a/src/cfml/system/modules_app/coldbox-commands/templates/InterceptorContent.txt
+++ b/src/cfml/system/modules_app/coldbox-commands/templates/InterceptorContent.txt
@@ -1,6 +1,6 @@
 <cfcomponent hint="|description|" output="false">
 
-<!------------------------------------------- CONFIGURATOR ------------------------------------------->
+<!------------------------------------------- CONFIGURATOR -------------------------------------------------->
 
 	<cffunction name="configure" access="public" returntype="void" output="false" hint="Interceptor config">
 		<cfscript>
@@ -10,6 +10,6 @@
 
 <!------------------------------------------- INTERCEPTION POINTS ------------------------------------------->
 
-|interceptionPoints|	
+|interceptionPoints|
 
-</cfcomponent>	
+</cfcomponent>

--- a/src/cfml/system/modules_app/coldbox-commands/templates/InterceptorMethodScript.txt
+++ b/src/cfml/system/modules_app/coldbox-commands/templates/InterceptorMethodScript.txt
@@ -1,3 +1,3 @@
 	void function |interceptionPoint|( event, rc, pc, interceptData, buffer ){
 		
-	}	
+	}

--- a/src/cfml/system/modules_app/coldbox-commands/templates/ModelContent.txt
+++ b/src/cfml/system/modules_app/coldbox-commands/templates/ModelContent.txt
@@ -1,7 +1,7 @@
 <cfcomponent hint="|modelDescription|" output="false" |modelPersistence||accessors|>
 
-    <!--- Properties --->
-    |properties|
+	<!--- Properties --->
+	|properties|
 
 <!------------------------------------------- CONSTRUCTOR ------------------------------------------->
 
@@ -14,4 +14,4 @@
 <!------------------------------------------- PUBLIC ------------------------------------------->
 
 |methods|
-</cfcomponent>	
+</cfcomponent>

--- a/src/cfml/system/modules_app/coldbox-commands/templates/ModelContentScript.txt
+++ b/src/cfml/system/modules_app/coldbox-commands/templates/ModelContentScript.txt
@@ -3,12 +3,12 @@
 */
 component |modelPersistence||accessors|{
 	
-    // Properties
-    |properties|
+	// Properties
+	|properties|
 
-    /**
-     * Constructor
-     */
+	/**
+	 * Constructor
+	 */
 	|modelName| function init(){
 		
 		return this;

--- a/src/cfml/system/modules_app/coldbox-commands/templates/testing/InterceptorBDDContentScript.txt
+++ b/src/cfml/system/modules_app/coldbox-commands/templates/testing/InterceptorBDDContentScript.txt
@@ -26,8 +26,8 @@ component extends="coldbox.system.testing.BaseInterceptorTest" interceptor="|nam
 			
 			it( "should configure correctly", function(){
 				interceptor.configure();
-                // Expectations here.
-                expect( false ).toBeTrue();
+				// Expectations here.
+				expect( false ).toBeTrue();
 			});
 			
 |TestCases|			

--- a/src/cfml/system/modules_app/coldbox-commands/templates/testing/InterceptorTestContent.txt
+++ b/src/cfml/system/modules_app/coldbox-commands/templates/testing/InterceptorTestContent.txt
@@ -12,8 +12,8 @@
 			// init and configure interceptor
 			super.setup();
 			// we are now ready to test this interceptor
-	  
-	  </cfscript>
+		
+		</cfscript>
 	</cffunction>
 	
 	<cffunction name="testConfigure">
@@ -22,7 +22,7 @@
 		
 			// test configure
 			interceptor.configure();
-	  </cfscript>
+		</cfscript>
 	</cffunction>
 	
 |TestCases|

--- a/src/cfml/system/modules_app/coldbox-commands/templates/testing/ModelBDDContentScript.txt
+++ b/src/cfml/system/modules_app/coldbox-commands/templates/testing/ModelBDDContentScript.txt
@@ -9,7 +9,7 @@ component extends="coldbox.system.testing.BaseModelTest" model="|modelPath|"{
 
 	function beforeAll(){
 		// setup the model
-		super.setup();		
+		super.setup();
 		
 		// init the model object
 		model.init();

--- a/src/cfml/system/modules_app/coldbox-commands/templates/testing/ModelBDDMethodContent.txt
+++ b/src/cfml/system/modules_app/coldbox-commands/templates/testing/ModelBDDMethodContent.txt
@@ -1,3 +1,3 @@
 			it( "should |method|", function(){
-                expect( false ).toBeTrue();
+				expect( false ).toBeTrue();
 			});

--- a/src/cfml/system/modules_app/coldbox-commands/templates/testing/ModelBDDMethodContentScript.txt
+++ b/src/cfml/system/modules_app/coldbox-commands/templates/testing/ModelBDDMethodContentScript.txt
@@ -1,3 +1,3 @@
 			it( "should |method|", function(){
-                expect( false ).toBeTrue();
+				expect( false ).toBeTrue();
 			});

--- a/src/cfml/system/modules_app/coldbox-commands/templates/testing/ModelTestContent.txt
+++ b/src/cfml/system/modules_app/coldbox-commands/templates/testing/ModelTestContent.txt
@@ -10,7 +10,7 @@
 		super.setup();
 		
 		// init the model object
-		model.init();	
+		model.init();
 		
 		</cfscript>
 	</cffunction>

--- a/src/cfml/system/modules_app/coldbox-commands/templates/testing/ModelTestContentScript.txt
+++ b/src/cfml/system/modules_app/coldbox-commands/templates/testing/ModelTestContentScript.txt
@@ -9,7 +9,7 @@ component extends="coldbox.system.testing.BaseModelTest" model="models.|modelNam
 		super.setup();
 		
 		// init the model object
-		model.init();	
+		model.init();
 		
 	}
 |TestCases|


### PR DESCRIPTION
Remove the mix of spaces and tabs and standardize on the one, true method (tabs)
Also remove trailing whitespace from non-blank lines
