### PR TITLE
Proposed changes for working with already started servers 

### DIFF
--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -886,6 +886,9 @@ component accessors="true" singleton {
 			// Delete server.json if it exists
 			if( fileExists( serverJSONPath ) ) {
 				fileDelete( serverJSONPath );
+				// return now so we don't wipe out the original server.json file too in the next 
+				// if statement! (because this was a "server-#name#.json" file) 
+				return "Poof! Wiped out server " & serverInfo.name;
 			}
 			if( fileExists( defaultServerJSONPath ) ) {
 				fileDelete( defaultServerJSONPath );

--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -215,6 +215,8 @@ component accessors="true" singleton {
 			// The recursive call here will subject their answer to the same check until they provide a name that hasn't been used for this folder.
 			if( len( newName ) ) {
 				serverProps.name = newName;
+				//copy the orig server's server.json file to the new file so it starts with the same properties as the original. lots of alternative ways to do this but the file copy works and is simple
+				file action='copy' source="#defaultServerConfigFile#" destination=fileSystemUtil.resolvePath( serverProps.directory ?: '' ) & "/server-#serverProps.name#.json" mode ='777';  		
 				return start( serverProps );
 			}
 		}


### PR DESCRIPTION
2 commits here. both are 1 liners. Simple changes.  Just some things I ran into while working with commandbox that didn't "feel" right. 

When you start a server that has already been running, it prompts for a new name. If you give it a new name, none of the settings you already had in the original server's server.json make it on the new server. So the first commit simply copies the server.json from orig server to the "server-#name#.json" file that would be created for the newly started server. This way, all the properties of the orig server are present on the second server.  
 
When you forget a "second" server,  it wipes out  the original server.json file as well. My second commit changes this behavior and prevents the orig server.json file from being wiped when you aren't deleting the original server.  