### PR TITLE
Implements the ability to pass a custom timeout for server startup

### DIFF
--- a/src/cfml/system/modules_app/server-commands/commands/server/start.cfc
+++ b/src/cfml/system/modules_app/server-commands/commands/server/start.cfc
@@ -108,7 +108,8 @@ component aliases="start" {
 		boolean	saveSettings=true,
 		String  cfengine,
 		String  WARPath,
-		String serverConfigFile
+		String serverConfigFile,
+		Numeric timeout
 	){
 
 		// This is a common mis spelling

--- a/src/cfml/system/modules_app/server-commands/commands/server/start.cfc
+++ b/src/cfml/system/modules_app/server-commands/commands/server/start.cfc
@@ -77,6 +77,7 @@ component aliases="start" {
 	 * @cfengine.optionsUDF  cfengineNameComplete
 	 * @WARPath				sets the path to an existing war to use
 	 * @serverConfigFile 	The path to the server's JSON file.  Created if it doesn't exist.
+	 * @timeout 			A custom timeout value for the server startup.
 	 
 	 **/
 	function run(

--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -351,6 +351,11 @@ component accessors="true" singleton {
 			    case "timeout":
 			    case "startTimeout":
 			    	serverJSON[ 'startTimeout' ] = serverProps[ prop ];
+			    	//normalize our name conventions if the alias is passed
+			    	if( prop == 'timeout' ){
+			    		serverProps[ 'startTimeout' ] = serverProps[ prop ];
+			    	}
+
 			    	break;
 			    default: 
 					serverJSON[ prop ] = serverProps[ prop ];
@@ -425,7 +430,7 @@ component accessors="true" singleton {
 		serverInfo.runwarArgs		= ( serverProps.runwarArgs		?: serverJSON.runwar.args ?: '' ) & ' ' & defaults.runwar.args;
 
 		// Server startup timeout
-		serverInfo.startTimeout		= serverProps.timeout 			?: serverJSON.startTimeout 	?: defaults.startTimeout;
+		serverInfo.startTimeout		= serverProps.startTimeout 			?: serverJSON.startTimeout 	?: defaults.startTimeout;
 				
 		// Global defauls are always added on top of whatever is specified by the user or server.json
 		serverInfo.libDirs		= ( serverProps.libDirs		?: serverJSON.app.libDirs ?: '' ).listAppend( defaults.app.libDirs );

--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -117,6 +117,7 @@ component accessors="true" singleton {
 		return {
 			name : d.name ?: '',
 			openBrowser : d.openBrowser ?: true,
+			startTimeout : 120,
 			stopsocket : d.stopsocket ?: 0,
 			debug : d.debug ?: false,
 			trayicon : d.trayicon ?: '',
@@ -161,8 +162,7 @@ component accessors="true" singleton {
 				cfengine : d.app.cfengine ?: ""
 			},
 			runwar : {
-				args : d.runwar.args ?: '',
-				startTimeout : 120
+				args : d.runwar.args ?: ''
 			}
 		};
 	}
@@ -349,7 +349,8 @@ component accessors="true" singleton {
 					serverJSON[ 'runwar' ][ 'args' ] = serverProps[ prop ];
 			         break;
 			    case "timeout":
-			    	serverJSON[ 'runwar' ][ 'startTimeout' ] = serverProps[ prop ];
+			    case "startTimeout":
+			    	serverJSON[ 'startTimeout' ] = serverProps[ prop ];
 			    	break;
 			    default: 
 					serverJSON[ prop ] = serverProps[ prop ];
@@ -424,7 +425,7 @@ component accessors="true" singleton {
 		serverInfo.runwarArgs		= ( serverProps.runwarArgs		?: serverJSON.runwar.args ?: '' ) & ' ' & defaults.runwar.args;
 
 		// Server startup timeout
-		serverInfo.startTimeout		= serverProps.timeout 			?: serverJSON.runwar.startTimeout 	?: defaults.runwar.startTimeout;
+		serverInfo.startTimeout		= serverProps.timeout 			?: serverJSON.startTimeout 	?: defaults.startTimeout;
 				
 		// Global defauls are always added on top of whatever is specified by the user or server.json
 		serverInfo.libDirs		= ( serverProps.libDirs		?: serverJSON.app.libDirs ?: '' ).listAppend( defaults.app.libDirs );
@@ -594,8 +595,8 @@ component accessors="true" singleton {
 	// Increase our startup allowance for Adobe engines, since a number of files are generated on the first request
 	var startupTimeout = serverInfo.startTimeout;
 
-	if( startupTimeout == defaults.runwar.startTimeout && findNoCase( 'adobe', CFEngineName ) ){
-		var startupTimeout= ( defaults.runwar.startTimeout * 2 );
+	if( startupTimeout == defaults.startTimeout && findNoCase( 'adobe', CFEngineName ) ){
+		var startupTimeout= ( defaults.startTimeout * 2 );
 	}
 							
 	// The java arguments to execute:  Shared server, custom web configs

--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -581,13 +581,16 @@ component accessors="true" singleton {
 		'tooltip' : processName,
 		'items' : serverInfo.trayOptions
 	};
+	
 	fileWrite( trayOptionsPath,  serializeJSON( trayJSON ) );
-
-
-	var startupTimeout = 120;
+	
 	// Increase our startup allowance for Adobe engines, since a number of files are generated on the first request
-	if( CFEngineName == 'adobe' ){
-		startupTimeout=240;
+	if( structKeyExists( serverInfo, 'timeout' ) ){
+		var startupTimeout = serverInfo.timeout;
+	} else if( findNoCase( 'adobe', CFEngineName ) ){
+		var startupTimeout=240;
+	} else {
+		var startupTimeout = 120;
 	}
 							
 	// The java arguments to execute:  Shared server, custom web configs


### PR DESCRIPTION
Allows the startup command to receive a custom timeout argument.   The intention is to prevent timeouts on initial Adobe server startup when using container-based infrastructure.

Example:  https://travis-ci.org/jclausen/cbox-module-template/builds/177273223