### PR TITLE
Update reinit.cfc

### DIFF
--- a/src/cfml/system/modules_app/coldbox-commands/commands/coldbox/reinit.cfc
+++ b/src/cfml/system/modules_app/coldbox-commands/commands/coldbox/reinit.cfc
@@ -25,7 +25,7 @@ component aliases="fwreinit" {
 		if( structCount( serverInfo ) eq 0 ){
 			print.boldRedLine( "No server configurations found for '#getCWD()#', so have no clue what to reinit buddy!" );
 		} else {
-			var thisURL = "localhost:#serverInfo.port#/?fwreinit=#arguments.password#";
+			var thisURL = "#serverInfo.host#:#serverInfo.port#/?fwreinit=#arguments.password#";
 			print.greenLine( "Hitting...#thisURL#" );
 			http result="local.results" 
 				 url="#thisURL#";


### PR DESCRIPTION
Use serverInfo.host so that 'coldbox reinit' will work on servers that were started with an alternative host defined.