### PR TITLE
Use Callable Interface instead of super class

### DIFF
--- a/src/java/com/ortussolutions/commandbox/jgit/CommandCaller.java
+++ b/src/java/com/ortussolutions/commandbox/jgit/CommandCaller.java
@@ -26,7 +26,7 @@ public class CommandCaller {
 	 * @return Whatever results that come back from the Jgit command's calling
 	 * @throws Exception
 	 */
-	public Object call( GitCommand command ) throws Exception {
+	public Object call( Callable command ) throws Exception {
 
 		try { 
 			


### PR DESCRIPTION
Not all the jGit commands extend `GitCommand` (like `InitCommand`), but all of them implement `Callable`.