### PR TITLE
Check that the boxOptions testbox property isn't blank before using it.

### DIFF
--- a/src/cfml/system/modules_app/testbox-commands/commands/testbox/run.cfc
+++ b/src/cfml/system/modules_app/testbox-commands/commands/testbox/run.cfc
@@ -93,7 +93,7 @@ component {
 				testboxURL &= "&#thisOption#=#arguments[ thisOption ]#";
 			}
 			// Check runtime options now
-			else if( boxOptions.keyExists( thisOption ) ){
+			else if( boxOptions.keyExists( thisOption ) && len( boxOptions[ thisOption ] ) ){
 				testboxURL &= "&#thisOption#=#boxOptions[ thisOption ]#";
 			}
 			// Defaults


### PR DESCRIPTION
Running `box testbox run runner='http://127.0.0.1:8500/tests/runner.cfm'` now errors when it didn't use to.

This is creating errors in ACF and Lucee
* `invalid component definition, can't find component []` on Lucee.
* `The '' name is not a valid component or interface name.` on ACF.

This seems to be because TestBox is trying to instantiate a reporter called `''`, which obviously doesn't exist.  

```
# Old CommandBox Behavior
$ box testbox run runner='http://127.0.0.1:8500/tests/runner.cfm'
Executing tests via http://127.0.0.1:8500/tests/runner.cfm?&recurse=true&reporter=json, please wait...

# New CommandBox Behavior
$ box testbox run runner='http://127.0.0.1:8500/tests/runner.cfm'
Executing tests via http://127.0.0.1:8500/tests/runner.cfm?&testSpecs=&directory=tests.specs&labels=&recurse=true&reporter=&testBundles=&bundles=&testSuites=, please wait...
```

The culprit seems to be the default `testbox` struct when getting the `boxOptions`.  This pull request makes sure that the key isn't blank before appending the option. 