### PR TITLE
Added link to bug tracker, since there is no Issues tab on Github

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,10 @@ Download from the [Ortus Integration Repository](http://integration.stg.ortussol
 
 Get going with CommandBox in a matter of minutes with our [Getting Started Guide](http://ortus.gitbooks.io/commandbox-documentation/content/getting_started_guide.html) 
 
+**Bug Tracker**
+
+Found an issue? Check out [Bug Tracker](https://ortussolutions.atlassian.net/browse/COMMANDBOX)
+
 
 ## DOCUMENTATION
 


### PR DESCRIPTION
Seems pretty necessary to link to the bug tracker on Atlassian, since the only other option is Googling "Commandbox Issues" or tagging Ortus on Twitter. (Hey, it did cross my mind.)

Obviously, if y'all want to change the wording go ahead.

Thanks!