### PR TITLE
Small fixes regarding searching for and install private packages from ForgeBox.

### DIFF
--- a/src/cfml/system/endpoints/ForgeBox.cfc
+++ b/src/cfml/system/endpoints/ForgeBox.cfc
@@ -306,7 +306,8 @@ component accessors="true" implements="IEndpointInteractive" singleton {
 	* @package The full endpointID like foo@1.0.0
 	*/
 	public function parseSlug( required string package ) {
-		return listFirst( arguments.package, '@' );
+		var matches = REFindNoCase( "^(\@?.+)\@(.+)", package, 1, true );
+		return mid( package, matches.pos[ 2 ], matches.len[ 2 ] );
 	}
 
 	/**
@@ -316,10 +317,11 @@ component accessors="true" implements="IEndpointInteractive" singleton {
 	public function parseVersion( required string package ) {
 		var version = 'stable';
 		// foo@1.0.0
-		if( arguments.package contains '@' ) {
+		var matches = REFindNoCase( "^(\@?.+)\@(.+)", package, 1, true );
+		if ( matches.pos.len() >= 3 ) {
 			// Note this can also be a semver range like 1.2.x, >2.0.0, or 1.0.4-2.x
 			// For now I'm assuming it's a specific version
-			version = listRest( arguments.package, '@' );
+			version = mid( package, matches.pos[ 3 ], matches.len[ 3 ] );
 		}
 		return version;
 	}

--- a/src/cfml/system/services/EndpointService.cfc
+++ b/src/cfml/system/services/EndpointService.cfc
@@ -84,7 +84,7 @@ component accessors="true" singleton {
 				ID : endpointName & ':' & path
 			};
 		// Is it a GitHub user/repo?
-		} else if( !findNoCase( ':', arguments.ID ) && listLen( arguments.ID, '/' ) == 2 ) {
+		} else if( !findNoCase( ':', arguments.ID ) && !left( arguments.ID, 1 ) == "@" && listLen( arguments.ID, '/' ) == 2 ) {
 			var endpointName =  'github';
 			return {
 				endpointName : endpointName,


### PR DESCRIPTION
Currently, trying to install a private ForgeBox package will not work.  The `@` symbol is removed by CommandBox, but is required when looking up the package on ForgeBox. (If `@ortus/test` is the package, the url must be `/entries/@ortus/test`, but currently CommandBox sends up `/entries/ortus/test`.)

Additionally, the git endpoint was the default endpoint when trying to install private ForgeBox packages.  This has been tweaked so that ForgeBox is the default for this kind of slug.