### PR TITLE
Add server list option to filter by webroot

### DIFF
--- a/src/cfml/system/modules_app/server-commands/commands/server/list.cfc
+++ b/src/cfml/system/modules_app/server-commands/commands/server/list.cfc
@@ -19,6 +19,7 @@
  * server list --stopped
  * server list --starting
  * server list --unknown
+ * server list --local
  * {code}
  * .
  * You can also supply a comma-delimited list of server short names to display
@@ -47,6 +48,7 @@ component {
 	 * @starting.hint Show starting servers
 	 * @unknown.hint Show servers with unknown status
 	 * @verbose.hint Show detailed information
+	 * @local.hint Show servers with webroot matching the current directory
 	 **/
 	function run(
 		name='',
@@ -54,7 +56,8 @@ component {
 		boolean stopped = false,
 		boolean starting = false,
 		boolean unknown = false,
-		boolean verbose = false ){
+		boolean verbose = false,
+		boolean local = false ){
 		var servers = serverService.getServers();
 
 		var statusList = '';
@@ -76,7 +79,8 @@ component {
 
 			// Check name and status filters.  By default, everything shows
 			if( ( !len( arguments.name ) || matchesName( thisServerInfo.name, arguments.name ) )
-				&& ( !len( statusList ) || listFindNoCase( statusList, status ) ) ) {
+				&& ( !len( statusList ) || listFindNoCase( statusList, status ) ) 
+				&& ( !arguments.local || getCanonicalPath(getCWD()) == getCanonicalPath(thisServerInfo.webroot) ) ) {
 
 				// Null Checks, to guarnatee correct struct.
 				structAppend( thisServerInfo, serverService.newServerInfoStruct(), false );


### PR DESCRIPTION
Show only servers that have the same webroot as the `pwd` in the `server list` command.
https://ortussolutions.atlassian.net/browse/COMMANDBOX-663

Implemented as `server list --local` feel free to change the name if you can think of a better one.

I also debated if it should allow a path to filter by, but I think it is simpler to just have a boolean arg, you can always cd to the path first then do `server list --local`