### PR TITLE
Correctly set slug for private packages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ org.eclipse.jdt.ui.prefs
 apidocs/docbox
 commandbox.rb
 /testbox
+jmimemagic.log
 
 # CommandBox config
 src/CommandBox.json

--- a/src/cfml/system/modules_app/package-commands/commands/package/init.cfc
+++ b/src/cfml/system/modules_app/package-commands/commands/package/init.cfc
@@ -22,6 +22,7 @@ component aliases="init" {
 
 	// DI
 	property name="PackageService" 	inject="PackageService";
+	property name="configService"	inject="configService";
 
 	/**
 	 * @name The human-readable name for this package
@@ -62,6 +63,22 @@ component aliases="init" {
 		}
 		if( len( boxJSON.slug ) && arguments.slug == 'my-package' ) {
 			structDelete( arguments, 'slug' );
+		}
+
+		if( structKeyExists( arguments, 'slug' ) && arguments.private ){
+			var APIToken = configService.getSetting( 'endpoints.forgebox.APIToken', '' );
+			if( ! len( APIToken ) ){
+				return error( "You must be logged in to ForgeBox to create a private package." );
+			}
+			var APITokens = configService.getSetting( 'endpoints.forgebox.tokens', {} );
+			var usernames = structKeyArray( APITokens );
+			var foundToken = usernames.filter( function( name ){
+				return APITokens[ name ] == APIToken;
+			} );
+			if( ! foundToken.len() ){
+				return error( "We're sorry, we're having problems locating your ForgeBox account.  Please `forgebox login` and try again." );
+			}
+			arguments.slug = "@#foundToken[ 1 ]#/#arguments.slug#";
 		}
 
 		// Ignore List


### PR DESCRIPTION
Includes error handling for users not logged in to ForgeBox or for
problems with the APITokens and tokens settings.