### PR TITLE
Commandbox crashed when entering the string "cfml" in the terminal

### DIFF
--- a/src/cfml/system/util/JLineHighlighter.cfc
+++ b/src/cfml/system/util/JLineHighlighter.cfc
@@ -56,7 +56,8 @@ component {
 						
 					}
 				// Check if the user is typing something like #now!
-				} else 	if( thisCommand.left( 4 ) == 'cfml' && variables.functionList.keyExists( command.parameters[ 1 ] ) ) {			
+				} else 	if( thisCommand.left( 4 ) == 'cfml' && command.parameters.len()
+				&& variables.functionList.keyExists( command.parameters[ 1 ] ) ) {
 					buffer = replaceNoCase( buffer, command.parameters[ 1 ], print.yellowBold( command.parameters[ 1 ] ) );
 				// All other "normal" commands
 				} else {


### PR DESCRIPTION
Noticed an error while playing with commandbox, using it from compiled source:

```
   _____                                          _ ____
  / ____|                                        | |  _ \
 | |     ___  _ __ ___  _ __ ___   __ _ _ __   __| | |_) | _____  __
 | |    / _ \| '_ ` _ \| '_ ` _ \ / _` | '_ \ / _` |  _ < / _ \ \/ /
 | |___| (_) | | | | | | | | | | | (_| | | | | (_| | |_) | (_) >  <
  \_____\___/|_| |_| |_|_| |_| |_|\__,_|_| |_|\__,_|____/ \___/_/\_\   v4.0.0-SNAPSHOT+00002

Welcome to CommandBox!
Type "help" for help, or "help [command]" to be more specific.

CommandBox:4.0.0-SNAPSHOT> cfmERROR (4.0.0-SNAPSHOT+00002)

Element at position [1] does not exist in list
Array index out of range: 0
/Users/frinky/.CommandBox/cfml/system/util/JLineHighlighter.cfc: line 59
57: 					}
58: 				// Check if the user is typing something like #now!
59: 				} else 	if( thisCommand.left( 4 ) == 'cfml' && variables.functionList.keyExists( command.parameters[ 1 ] ) ) {			
60: 					buffer = replaceNoCase( buffer, command.parameters[ 1 ], print.yellowBold( command.parameters[ 1 ] ) );
61: 				// All other "normal" commands
called from /Users/frinky/.CommandBox/cfml/system/Shell.cfc: line 497
495: 			        	line = variables.reader.readLine( interceptData.prompt, javacast( "char", ' ' ) );
496: 					} else {
497: 			        	line = variables.reader.readLine( interceptData.prompt );
498: 					}
499: 					
called from /Users/frinky/.CommandBox/cfml/system/Bootstrap.cfm: line 114
112: 
113: 		// Running the "reload" command will enter this while loop once
114: 		while( shell.run( silent=silent ) ){
115: 			clearScreen = shell.getDoClearScreen();
116: 
lucee.runtime.exp.ExpressionException: Element at position [1] does not exist in list
	at lucee.runtime.type.wrap.ListAsArray.getE(ListAsArray.java:108)
	at lucee.runtime.type.wrap.ListAsArray.get(ListAsArray.java:273)
	at lucee.runtime.type.wrap.ListAsArray.get(ListAsArray.java:278)
	at lucee.runtime.type.util.ArraySupport.get(ArraySupport.java:324)
	at lucee.runtime.util.VariableUtilImpl.get(VariableUtilImpl.java:263)
	at lucee.runtime.PageContextImpl.get(PageContextImpl.java:1467)
	at system.util.jlinehighlighter_cfc$cf.udfCall(/commandbox/system/util/JLineHighlighter.cfc:59)
	at lucee.runtime.type.UDFImpl.implementation(UDFImpl.java:107)
	at lucee.runtime.type.UDFImpl._call(UDFImpl.java:366)
	at lucee.runtime.type.UDFImpl.call(UDFImpl.java:226)
	at lucee.runtime.ComponentImpl._call(ComponentImpl.java:704)
	at lucee.runtime.ComponentImpl._call(ComponentImpl.java:587)
	at lucee.runtime.ComponentImpl.call(ComponentImpl.java:1960)
	at lucee.runtime.java.JavaProxy.call(JavaProxy.java:65)
	at lucee.runtime.op.JavaProxyUtilImpl.call(JavaProxyUtilImpl.java:12)
	at V1c02b05763f471af6c3eac5b923966814336.highlight(Unknown Source)
	at org.jline.reader.impl.LineReaderImpl.getHighlightedBuffer(LineReaderImpl.java:3468)
	at org.jline.reader.impl.LineReaderImpl.getDisplayedBufferWithPrompts(LineReaderImpl.java:3450)
	at org.jline.reader.impl.LineReaderImpl.redisplay(LineReaderImpl.java:3394)
	at org.jline.reader.impl.LineReaderImpl.doCleanup(LineReaderImpl.java:2271)
	at org.jline.reader.impl.LineReaderImpl.cleanup(LineReaderImpl.java:2263)
	at org.jline.reader.impl.LineReaderImpl.readLine(LineReaderImpl.java:589)
	at org.jline.reader.impl.LineReaderImpl.readLine(LineReaderImpl.java:390)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at lucee.runtime.reflection.pairs.MethodInstance.invoke(MethodInstance.java:55)
	at lucee.runtime.reflection.Reflector.callMethod(Reflector.java:852)
	at lucee.runtime.util.VariableUtilImpl.callFunctionWithoutNamedValues(VariableUtilImpl.java:797)
	at lucee.runtime.PageContextImpl.getFunction(PageContextImpl.java:1698)
	at system.shell_cfc$cf.udfCall3(/commandbox/system/Shell.cfc:497)
	at system.shell_cfc$cf.udfCall(/commandbox/system/Shell.cfc)
	at lucee.runtime.type.UDFImpl.implementation(UDFImpl.java:107)
	at lucee.runtime.type.UDFImpl._call(UDFImpl.java:366)
	at lucee.runtime.type.UDFImpl.callWithNamedValues(UDFImpl.java:212)
	at lucee.runtime.ComponentImpl._call(ComponentImpl.java:705)
	at lucee.runtime.ComponentImpl._call(ComponentImpl.java:587)
	at lucee.runtime.ComponentImpl.callWithNamedValues(ComponentImpl.java:1981)
	at lucee.runtime.util.VariableUtilImpl.callFunctionWithNamedValues(VariableUtilImpl.java:833)
	at lucee.runtime.PageContextImpl.getFunctionWithNamedValues(PageContextImpl.java:1719)
	at users.frinky._commandbox46.cfml.system.bootstrap_cfm$cf.call(/Users/frinky/.CommandBox/cfml/system/Bootstrap.cfm:114)
	at lucee.runtime.PageContextImpl._doInclude(PageContextImpl.java:939)
	at lucee.runtime.PageContextImpl._doInclude(PageContextImpl.java:833)
	at lucee.runtime.listener.ModernAppListener._onRequest(ModernAppListener.java:223)
	at lucee.runtime.listener.MixedAppListener.onRequest(MixedAppListener.java:43)
	at lucee.runtime.PageContextImpl.execute(PageContextImpl.java:2405)
	at lucee.runtime.PageContextImpl._execute(PageContextImpl.java:2395)
	at lucee.runtime.PageContextImpl.executeCFML(PageContextImpl.java:2363)
	at lucee.runtime.engine.Request.exe(Request.java:44)
	at lucee.runtime.engine.CFMLEngineImpl._service(CFMLEngineImpl.java:1091)
	at lucee.runtime.engine.CFMLEngineImpl.serviceCFML(CFMLEngineImpl.java:1039)
	at lucee.runtime.engine.CFMLEngineImpl.cli(CFMLEngineImpl.java:1474)
	at lucee.loader.engine.CFMLEngineWrapper.cli(CFMLEngineWrapper.java:280)
	at luceecli.CLIMain.run(CLIMain.java:223)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at cliloader.LoaderCLIMain.execute(LoaderCLIMain.java:199)
	at cliloader.LoaderCLIMain.main(LoaderCLIMain.java:626)
```