### PR TITLE
Only clamp major versions on valid semantic versions

### DIFF
--- a/src/cfml/system/services/PackageService.cfc
+++ b/src/cfml/system/services/PackageService.cfc
@@ -732,7 +732,11 @@ component accessors="true" singleton {
 				var thisValue = listLast( endpointData.package, '@' );
 			} else {
 				// caret version range (^1.2.3) allows updates that don't bump the major version.
-				var thisValue = '^' & arguments.version;
+				// Unless the version isn't really a semantic version.  Than just use what they gave us.
+				var thisValue = arguments.version;
+				if ( semanticVersion.isValid( thisValue ) ) {
+				    thisValue = '^' & thisValue;
+				}
 			}
 		} else {
 			var thisValue = endpointData.ID;


### PR DESCRIPTION
Some valid version ranges don't respond to clamping, like `*` or `latest`.  Check for these before clamping the version range.

Depends on https://github.com/Ortus-Solutions/semanticVersion/pull/2