### PR TITLE
Use only last section if a package contains slashes for installPaths

### DIFF
--- a/src/cfml/system/services/PackageService.cfc
+++ b/src/cfml/system/services/PackageService.cfc
@@ -220,8 +220,11 @@ component accessors="true" singleton {
 
 			}
 
-			// Default directory to package name
-			var packageDirectory = packageName;
+			// Default directory to package name.
+            		// The `listLast` is to handle packages with slashes (/) in them.
+            		// Instead of creating nested directories, we just use the last part
+            		// of the package name.
+			var packageDirectory = listLast( packageName, "/" );
 			
 			// Next, see if the containing project has an install path configured for this dependency already.
 			var containerBoxJSON = readPackageDescriptor( arguments.packagePathRequestingInstallation );


### PR DESCRIPTION
Since ColdBox modules (at least) don't deal with nested folders and private ForgeBox packages use a slash in the delimiter, only use the last section of any package slug with a slash (`/`) in it when setting the `installPaths`.

That means that a package like `@elpete/my-package` will become `my-package`.

The `box.json` will include keys that look like this:
```
"dependencies":{
        "@elpete/my-package":"^1.0.0"
    },
    "installPaths":{
        "@elpete/my-package":"modules/my-package"
    },
```