### PR TITLE
Parse new private package format

### DIFF
--- a/src/cfml/system/endpoints/ForgeBox.cfc
+++ b/src/cfml/system/endpoints/ForgeBox.cfc
@@ -78,9 +78,9 @@ component accessors="true" implements="IEndpointInteractive" singleton {
 		var slug 			= parseSlug( arguments.package );
 		var boxJSONversion 	= parseVersion( arguments.package );
 		var result 			= {
-								isOutdated 	= false,
-								version 	= ''
-							  };
+            isOutdated 	= false,
+            version 	= boxJSONversion
+        };
 
 		// Only bother checking if we have a version range.  If an exact version is stored in
 		// box.json, we're never going to update it anyway.

--- a/src/cfml/system/endpoints/ForgeBox.cfc
+++ b/src/cfml/system/endpoints/ForgeBox.cfc
@@ -340,7 +340,7 @@ component accessors="true" implements="IEndpointInteractive" singleton {
 	* @package The full endpointID like foo@1.0.0
 	*/
 	public function parseSlug( required string package ) {
-		var matches = REFindNoCase( "^((?:@[\w\-]+\/)?[\w\-]+)(?:@(.+))?", package, 1, true );
+		var matches = REFindNoCase( "^([a-zA-Z][\w\-\.]*(?:\@(?!stable\b)(?!be\b)[a-zA-Z][\w\-]*)?)(?:\@(.+))?$", package, 1, true );
 		if ( arrayLen( matches.len ) < 2 ) {
 			throw(
 				type = "endpointException",
@@ -357,7 +357,7 @@ component accessors="true" implements="IEndpointInteractive" singleton {
 	public function parseVersion( required string package ) {
 		var version = 'stable';
 		// foo@1.0.0
-		var matches = REFindNoCase( "^((?:@[\w\-]+\/)?[\w\-]+)(?:@(.+))?", package, 1, true );
+		var matches = REFindNoCase( "^([a-zA-Z][\w\-\.]*(?:\@(?!stable\b)(?!be\b)[a-zA-Z][\w\-]*)?)(?:\@(.+))?$", package, 1, true );
 		if ( matches.pos.len() >= 3 && matches.pos[ 3 ] != 0 ) {
 			// Note this can also be a semver range like 1.2.x, >2.0.0, or 1.0.4-2.x
 			// For now I'm assuming it's a specific version

--- a/src/cfml/system/modules_app/package-commands/commands/package/init.cfc
+++ b/src/cfml/system/modules_app/package-commands/commands/package/init.cfc
@@ -78,7 +78,7 @@ component aliases="init" {
 			if( ! foundToken.len() ){
 				return error( "We're sorry, we're having problems locating your ForgeBox account.  Please `forgebox login` and try again." );
 			}
-			arguments.slug = "@#foundToken[ 1 ]#/#arguments.slug#";
+			arguments.slug = "#arguments.slug#@#foundToken[ 1 ]#";
 		}
 
 		// Ignore List

--- a/src/cfml/system/services/PackageService.cfc
+++ b/src/cfml/system/services/PackageService.cfc
@@ -728,9 +728,9 @@ component accessors="true" singleton {
 		// Add/overwrite this dependency
 
 		if( endpointData.endpointName == 'forgebox' ) {
-
-			if( listLen( endpointData.package, '@' ) > 1 ) {
-				var thisValue = listLast( endpointData.package, '@' );
+            var parsedVersion = parseVersion( endpointData.package );
+			if( len( parsedVersion ) ) {
+				var thisValue = parsedVersion;
 			} else {
 				// caret version range (^1.2.3) allows updates that don't bump the major version.
 				var thisValue = '^' & arguments.version;
@@ -1153,10 +1153,29 @@ component accessors="true" singleton {
 	* @package The full endpointID like foo@1.0.0
 	*/
 	private function parseSlug( required string package ) {
-		var matches = REFindNoCase( "^((?:@[\w\-]+\/)?[\w\-]+)(?:@(.+))?", package, 1, true );
+		var matches = REFindNoCase( "^([a-zA-Z][\w\-\.]*(?:\@(?!stable\b)(?!be\b)[a-zA-Z][\w\-]*)?)(?:\@(.+))?$", package, 1, true );
 		if ( arrayLen( matches.len ) < 2 ) {
-			return package;
+			throw(
+				type = "endpointException",
+				message = "Invalid slug detected.  Slugs can only contain letters, numbers, underscores, and hyphens. They may also be prepended with an @ sign for private packages"
+			);
 		}
 		return mid( package, matches.pos[ 2 ], matches.len[ 2 ] );
+	}
+
+    /**
+	* Parses just the version portion out of an endpoint ID
+	* @package The full endpointID like foo@1.0.0
+	*/
+	private function parseVersion( required string package ) {
+		var version = '';
+		// foo@1.0.0
+		var matches = REFindNoCase( "^([a-zA-Z][\w\-\.]*(?:\@(?!stable\b)(?!be\b)[a-zA-Z][\w\-]*)?)(?:\@(.+))?$", package, 1, true );
+		if ( matches.pos.len() >= 3 && matches.pos[ 3 ] != 0 ) {
+			// Note this can also be a semver range like 1.2.x, >2.0.0, or 1.0.4-2.x
+			// For now I'm assuming it's a specific version
+			version = mid( package, matches.pos[ 3 ], matches.len[ 3 ] );
+		}
+		return version;
 	}
 }

--- a/src/cfml/system/util/ForgeBox.cfc
+++ b/src/cfml/system/util/ForgeBox.cfc
@@ -430,7 +430,12 @@ or just add DEBUG to the root logger
 
 		// error
 		if( results.response.error ){
-			throw( message = arrayToList( results.response.messages ), type = 'forgebox', errorcode = results.responseheader.status_code ?: 500 );
+            throw(
+                "Error getting ForgeBox storage location.",
+                "forgebox",
+                results.response.messages.toList(),
+                results.responseheader.status_code ?: 500
+            );
 		}
 
 		return results.response.data;


### PR DESCRIPTION
The new private package format is `{slug}@{username}`.
A version can also be appended (`{slug}@{username}@{version}`).

Normal packages work the same, including with versions. Note that
valid versions for packages either start with a non-letter character
or it is `be` or `stable` (which are accounted for as neither can be a
valid username).