### PR TITLE
Use unix style line endings so they can be interpreted by git

### DIFF
--- a/src/cfml/system/util/Formatter.cfc
+++ b/src/cfml/system/util/Formatter.cfc
@@ -218,6 +218,9 @@ component singleton {
 	 * @json.hint A string containing JSON, or a complex value that can be serialized to JSON
  	 **/
 	public function formatJson( json, indent, lineEnding ) {
+		if ( !structKeyExists(arguments, "lineEnding") )
+			arguments.lineEnding = variables.LF;
+
 		// This is an external lib now.  Leaving here for backwards compat.
 		return JSONPrettyPrint.formatJSON( argumentCollection=arguments );
 	}


### PR DESCRIPTION
The JSONPrettyPrint module is using windows style line endings by default. This means that files being written with content formatted by this utility are not compatible with GIT (any change to the file appears as an entire file replacement to the git diff)