### PR TITLE
Use stable as a default when no version is given.

### DIFF
--- a/src/cfml/system/services/ServerEngineService.cfc
+++ b/src/cfml/system/services/ServerEngineService.cfc
@@ -30,7 +30,7 @@ component accessors="true" singleton="true" {
 	* @serverHomeDirectory Override where the server's home with be
 	**/
 	public function install( required cfengine, required baseDirectory, required struct serverInfo, required string serverHomeDirectory ) {
-		var version = listLen( cfengine, "@" )>1 ? listLast( cfengine, "@" ) : "";
+		var version = listLen( cfengine, "@" )>1 ? listLast( cfengine, "@" ) : "stable";
 		var engineName = listFirst( cfengine, "@" );
 		arguments.baseDirectory = !arguments.baseDirectory.endsWith( "/" ) ? arguments.baseDirectory & "/" : arguments.baseDirectory;
 


### PR DESCRIPTION
Leaving the version off had us passing a slug around like `adobe@` which is not a valid slug.  This pull request will use `stable` as the version if there is no version specified in the ID.