### PR TITLE
COMMANDBOX-791 Remove hidden character that 'breaks' executable...

### DIFF
--- a/src/cfml/system/modules_app/server-commands/bin/server_spawner.sh
+++ b/src/cfml/system/modules_app/server-commands/bin/server_spawner.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 
 # In *nix OS's we need to separate the server process from the CLI process
 # so SIGINTs from Ctrl-C won't also kill previously started servers


### PR DESCRIPTION
…  (error message shows but code is still executed). Error message:

```
.CommandBox/cfml/system/modules_app/server-commands/bin/server_spawner.sh: line 1: ﻿#!/bin/bash: No such file or directory
```