### PR TITLE
COMMANDBOX-808 bash:no job control with this shell

### DIFF
--- a/src/cfml/system/modules_app/system-commands/commands/run.cfc
+++ b/src/cfml/system/modules_app/system-commands/commands/run.cfc
@@ -78,14 +78,14 @@ component{
 				.init( commandArray )
 				// Keyboard pipes through to the input of the process
 				.redirectInput( redirect.INHERIT )
-				// Error stream joins the standard out stream
-				.redirectErrorStream( true )
+				// redirectErrorStream(true) disables job control on *nix and causes the dreaded "bash:no job control for this shell" message
+				.redirectError(Redirect.INHERIT)
 				// Sets current working directory for the process
 				.directory( CWDFile )
 				// Fires process async
 				.start();
 			
-			// Depsite the name, this is the stream that the *output* of the external process is in.
+			// Despite the name, this is the stream that the *output* of the external process is in.
 			var inputStream = process.getInputStream();
 			// I convert the byte array in the piped input stream to a character array
 			var inputStreamReader = createObject( 'java', 'java.io.InputStreamReader' ).init( inputStream );

--- a/src/cfml/system/modules_app/system-commands/commands/run.cfc
+++ b/src/cfml/system/modules_app/system-commands/commands/run.cfc
@@ -37,7 +37,7 @@
  *
  **/
 component{
-
+	property name="fileSystemUtil" inject="fileSystem"; 
 	property name="configService" inject="configService";
 
 	/**
@@ -78,12 +78,15 @@ component{
 				.init( commandArray )
 				// Keyboard pipes through to the input of the process
 				.redirectInput( redirect.INHERIT )
-				// redirectErrorStream(true) disables job control on *nix and causes the dreaded "bash:no job control for this shell" message
-				.redirectError(Redirect.INHERIT)
+				.redirectErrorStream(fileSystemUtil.isWindows())
 				// Sets current working directory for the process
-				.directory( CWDFile )
-				// Fires process async
-				.start();
+				.directory( CWDFile );
+
+			if(!fileSystemUtil.isWIndows()) {
+				process=process.redirectError(redirect.INHERIT);
+			}
+			// Fires process async
+			process=process.start();
 			
 			// Despite the name, this is the stream that the *output* of the external process is in.
 			var inputStream = process.getInputStream();

--- a/src/cfml/system/modules_app/system-commands/commands/run.cfc
+++ b/src/cfml/system/modules_app/system-commands/commands/run.cfc
@@ -59,7 +59,7 @@ component{
 			// Pass through bash in interactive mode with -i to expand aliases like "ll".
 			// -c runs input as a command, "&& exits" cleanly from the shell as long as the original command ran successfully
 			var nativeShell = configService.getSetting( 'nativeShell', '/bin/bash' );
-			commandArray = [ nativeShell, '-i', '-c', arguments.command & ' && ( exit $? > /dev/null )' ];
+			commandArray = [ nativeShell, '-i', '-c', arguments.command & ' 2>&1 && ( exit $? > /dev/null )' ];
 		}
 
 		try{


### PR DESCRIPTION
This fixes the "bash: no job control in this shell" error seen in bash shells.  Replacing ".redirectErrorStream()" with ".redirectError(Redirect.INHERIT)" removes that annoying message, enables job control, expands aliases, and, as far as I can tell, all functionality regarding redirection of output and errors works as it does today in 4.0.0.  

You might want to do more thorough testing across all OSes, but from what I can tell, this doesn't break any functionality. 

see https://groups.google.com/a/ortussolutions.com/forum/#!topic/commandbox/XRzhVd2Tusw
for the original discussion 