### PR TITLE
S3 endpoint output

### DIFF
--- a/src/cfml/system/endpoints/S3.cfc
+++ b/src/cfml/system/endpoints/S3.cfc
@@ -45,20 +45,20 @@ component accessors="true" implements="IEndpoint" singleton {
                 presignedPath, // URL to package
                 fullPath, // Place to store it locally
                 function(status) {
-                    progressBar.update( argumentCollection = status );
+                    progressBar.update(argumentCollection = status);
                 },
                 function(newURL) {
-                    job.addLog( "Redirecting to: '#arguments.newURL#'..." );
+                    job.addLog("Redirecting to: '#arguments.newURL#'...");
                 }
             );
-        } catch( UserInterruptException var e ) {
+        } catch(UserInterruptException var e) {
             rethrow;
-        } catch( Any var e ) {
-            throw( '#e.message##CR##e.detail#', 'endpointException' );
+        } catch(Any var e) {
+            throw('#e.message##CR##e.detail#', 'endpointException');
         };
 
         // Defer to file endpoint
-        return fileEndpoint.resolvePackage( fullPath, arguments.verbose );
+        return fileEndpoint.resolvePackage(fullPath, arguments.verbose);
     }
 
     public function getDefaultName(required string package) {

--- a/src/cfml/system/endpoints/S3.cfc
+++ b/src/cfml/system/endpoints/S3.cfc
@@ -10,8 +10,14 @@
 component accessors="true" implements="IEndpoint" singleton {
 
     // DI
-    property name="httpsEndpoint" inject="commandbox.system.endpoints.HTTPS";
-    property name="S3Service"     inject="S3Service";
+    property name="CR"                     inject="CR@constants";
+    property name="fileEndpoint"           inject="commandbox.system.endpoints.File";
+    property name="httpsEndpoint"          inject="commandbox.system.endpoints.HTTPS";
+    property name="progressableDownloader" inject="ProgressableDownloader";
+    property name="progressBar"            inject="ProgressBar";
+    property name="S3Service"              inject="S3Service";
+    property name="tempDir"                inject="tempDir@constants";
+    property name='wirebox'                inject='wirebox';
 
     // Properties
     property name="namePrefixes" type="string";
@@ -22,8 +28,37 @@ component accessors="true" implements="IEndpoint" singleton {
     }
 
     public string function resolvePackage(required string package, boolean verbose=false) {
-        var presignedPath = s3Service.generateSignedURL('s3:' & package, verbose);
-        return httpsEndpoint.resolvePackage(presignedPath.listRest(':'), verbose);
+        var job = wirebox.getInstance('interactiveJob');
+
+        var fileName = 'temp#randRange( 1, 1000 )#.zip';
+        var fullPath = tempDir & '/' & fileName;
+
+        job.addLog('Downloading [s3:#package#]');
+
+        try {
+            // Download File
+            var presignedPath = s3Service.generateSignedURL('s3:' & package, verbose);
+            if (verbose) {
+                job.addLog('Signed URL: ' & presignedPath);
+            }
+            var result = progressableDownloader.download(
+                presignedPath, // URL to package
+                fullPath, // Place to store it locally
+                function(status) {
+                    progressBar.update( argumentCollection = status );
+                },
+                function(newURL) {
+                    job.addLog( "Redirecting to: '#arguments.newURL#'..." );
+                }
+            );
+        } catch( UserInterruptException var e ) {
+            rethrow;
+        } catch( Any var e ) {
+            throw( '#e.message##CR##e.detail#', 'endpointException' );
+        };
+
+        // Defer to file endpoint
+        return fileEndpoint.resolvePackage( fullPath, arguments.verbose );
     }
 
     public function getDefaultName(required string package) {

--- a/src/cfml/system/services/S3Service.cfc
+++ b/src/cfml/system/services/S3Service.cfc
@@ -58,7 +58,6 @@ component accessors="true" singleton {
 		// if objectKey does not end in `.zip` we have to do a HEAD request to see if the path is valid as is
 		// or if .zip should be appended to it - this is for backward compat with https://github.com/pixl8/s3-commandbox-commands
 		if (!objectKey.endsWith('.zip')) {
-			var job = wirebox.getInstance('interactiveJob');
 			if (verbose) {
 				job.addLog('Validating object key since it does not have a .zip extension');
 			}


### PR DESCRIPTION
While deferring to the HTTP endpoint for the file download is more elegant, it results in the printing out of the whole (inevitably multi line) signed URL during download to the console even on a non-verbose install. By doing it this way, the S3 path is what gets printed out by default, and then the long signed URL is logged separately on a verbose install. I prefer this, but I understand if you want to avoid the code duplication.