### PR TITLE
COMMANDBOX-864

### DIFF
--- a/src/cfml/system/Shell.cfc
+++ b/src/cfml/system/Shell.cfc
@@ -830,7 +830,7 @@ component accessors="true" singleton {
 			if( isArray( result ) ){
 				return variables.reader.getTerminal().writer().printColumns( result );
 			}
-			result = variables.formatterUtil.formatJson( serializeJSON( result ) );
+			result = variables.formatterUtil.formatJson( result );
 			printString( result );
 		} else if( !isNull( result ) && len( result ) ) {
 			// If there is an active job, print our output through it

--- a/src/cfml/system/endpoints/Jar.cfc
+++ b/src/cfml/system/endpoints/Jar.cfc
@@ -16,7 +16,7 @@ component accessors=true implements="IEndpoint" singleton {
 	property name="progressableDownloader" 	inject="ProgressableDownloader";
 	property name="progressBar" 			inject="ProgressBar";
 	property name="CR" 						inject="CR@constants";
-	property name='formatterUtil'			inject='formatter';
+	property name='JSONService'				inject='JSONService';
 	property name='wirebox'					inject='wirebox';
 	property name='S3Service'				inject='S3Service';
 
@@ -63,7 +63,7 @@ component accessors=true implements="IEndpoint" singleton {
 			'location' : 'jar:#package#',
 			'type' : 'jars'
 		};
-		fileWrite( fullBoxJSONPath, formatterUtil.formatJSON( boxJSON ) );
+		JSONService.writeJSONFile( fullBoxJSONPath, boxJSON );
 
 		// Here is where our alleged so-called "package" lives.
 		return folderName;

--- a/src/cfml/system/modules_app/package-commands/commands/package/list.cfc
+++ b/src/cfml/system/modules_app/package-commands/commands/package/list.cfc
@@ -58,7 +58,7 @@ component aliases="list" {
 
 		// JSON output
 		if( arguments.JSON ) {
-			print.line( formatterUtil.formatJson( serializeJSON( tree ) ) );
+			print.line( formatterUtil.formatJson( tree ) );
 			return;
 		}
 		// normal output

--- a/src/cfml/system/modules_app/package-commands/commands/package/outdated.cfc
+++ b/src/cfml/system/modules_app/package-commands/commands/package/outdated.cfc
@@ -61,7 +61,7 @@ component aliases="outdated" {
 
 		// JSON output
 		if( arguments.JSON ) {
-			print.line( formatterUtil.formatJson( serializeJSON( aOutdatedDependencies ) ) );
+			print.line( formatterUtil.formatJson( aOutdatedDependencies ) );
 			return;
 		}
 

--- a/src/cfml/system/modules_app/server-commands/commands/server/status.cfc
+++ b/src/cfml/system/modules_app/server-commands/commands/server/status.cfc
@@ -65,7 +65,7 @@ component aliases='status,server info' {
 		// Display ALL as JSON?
 		if( arguments.showALL && arguments.json ){
 			print.line(
-				formatterUtil.formatJson( serializeJSON( servers ) )
+				formatterUtil.formatJson( servers )
 			);
 			return;
 		}
@@ -114,7 +114,7 @@ component aliases='status,server info' {
 						// Format Complex values as JSON
 						} else {
 							print.line(
-								formatterUtil.formatJson( serializeJSON( thisValue ) )
+								formatterUtil.formatJson( thisValue )
 							);
 						}
 
@@ -122,7 +122,7 @@ component aliases='status,server info' {
 
 						// Output the entire object
 						print.line(
-							formatterUtil.formatJson( serializeJSON( thisServerInfo ) )
+							formatterUtil.formatJson( thisServerInfo )
 						);
 
 					}
@@ -171,7 +171,7 @@ component aliases='status,server info' {
 
 	/**
 	* AutoComplete server names
-	*/	
+	*/
 	function serverNameComplete() {
 		return serverService
 			.getServerNames()

--- a/src/cfml/system/services/ConfigService.cfc
+++ b/src/cfml/system/services/ConfigService.cfc
@@ -153,7 +153,7 @@ component accessors="true" singleton {
 	* Persists config settings to disk
 	*/
 	function saveConfig(){
-		fileWrite( getConfigFilePath(), formatterUtil.formatJSON( serializeJSON( getConfigSettings() ) ) );
+		JSONService.writeJSONFile( getConfigFilePath(), getConfigSettings() );
 
 		// Update ModuleService
 		ModuleService.overrideAllConfigSettings();

--- a/src/cfml/system/services/JSONService.cfc
+++ b/src/cfml/system/services/JSONService.cfc
@@ -220,7 +220,7 @@ component accessors="true" singleton {
 		var oldJSON = '';
 
 		if ( fileExists( path ) ) {
-			oldJSON = locking ? fileSytemUtil.lockingFileRead( path ) : fileRead( path );
+			oldJSON = locking ? fileSystemUtil.lockingFileRead( path ) : fileRead( path );
 			// if sortKeys is not explicitly set try to determine current file state
 			if ( !sortKeysIsSet && !isSortedJSON( oldJSON, sortKeys ) ) {
 				sortKeys = '';
@@ -237,7 +237,7 @@ component accessors="true" singleton {
 		directoryCreate( getDirectoryFromPath( path ), true, true );
 
 		if ( locking ) {
-			fileSytemUtil.lockingFileWrite( path, newJSON );
+			fileSystemUtil.lockingFileWrite( path, newJSON );
 		} else {
 			fileWrite( path, newJSON );
 		}

--- a/src/cfml/system/services/JSONService.cfc
+++ b/src/cfml/system/services/JSONService.cfc
@@ -11,7 +11,7 @@ component accessors="true" singleton {
 
 	// DI
 	property name="configService" inject="ConfigService";
-	property name="fileSytemUtil" inject="FileSystem";
+	property name="fileSystemUtil" inject="FileSystem";
 	property name="formatterUtil" inject="Formatter";
 	property name="logger"        inject="logbox:logger:{this}";
 
@@ -215,7 +215,7 @@ component accessors="true" singleton {
 		// if sortKeys is not explicitly set or writeOnChangeOnly is set
 		// try to determine current file state
 		if ( ( !sortKeysIsSet || writeOnChangeOnly ) && fileExists( path ) ) {
-			oldJSON = locking ? fileSytemUtil.lockingFileRead( path ) : fileRead( path );
+			oldJSON = locking ? fileSystemUtil.lockingFileRead( path ) : fileRead( path );
 			if ( !sortKeysIsSet && !isSortedJSON( oldJSON, sortKeys ) ) {
 				sortKeys = '';
 			}
@@ -231,7 +231,7 @@ component accessors="true" singleton {
 		directoryCreate( getDirectoryFromPath( path ), true, true );
 
 		if ( locking ) {
-			fileSytemUtil.lockingFileWrite( path, newJSON );
+			fileSystemUtil.lockingFileWrite( path, newJSON );
 		} else {
 			fileWrite( path, newJSON );
 		}

--- a/src/cfml/system/services/JSONService.cfc
+++ b/src/cfml/system/services/JSONService.cfc
@@ -208,17 +208,17 @@ component accessors="true" singleton {
 	}
 
 	function writeJSONFile( path, json, locking = false, writeOnChangeOnly = false ) {
+		var sortKeysIsSet = configService.settingExists( 'JSONPrettyPrint.sortKeys' );
 		var sortKeys = configService.getSetting( 'JSONPrettyPrint.sortKeys', 'textnocase' );
 		var oldJSON = '';
 
 		// if sortKeys is not explicitly set or writeOnChangeOnly is set
 		// try to determine current file state
-		if (
-			( !configService.settingExists( 'JSONPrettyPrint.sortKeys' ) || writeOnChangeOnly ) &&
-			fileExists( path )
-		) {
+		if ( ( !sortKeysIsSet || writeOnChangeOnly ) && fileExists( path ) ) {
 			oldJSON = locking ? fileSytemUtil.lockingFileRead( path ) : fileRead( path );
-			sortKeys = isSortedJSON( oldJSON, sortKeys ) ? sortKeys : '';
+			if ( !sortKeysIsSet && !isSortedJSON( oldJSON, sortKeys ) ) {
+				sortKeys = '';
+			}
 		}
 
 		var newJSON = formatterUtil.formatJson( json = json, sortKeys = sortKeys );

--- a/src/cfml/system/services/PackageService.cfc
+++ b/src/cfml/system/services/PackageService.cfc
@@ -921,12 +921,7 @@ component accessors="true" singleton {
 	* @directory The directory to write the box.json
 	*/
 	function writePackageDescriptor( required any JSONData, required directory ){
-
-		if( !isSimpleValue( JSONData ) ) {
-			JSONData = serializeJSON( JSONData );
-		}
-
-		fileWrite( getDescriptorPath( arguments.directory ), formatterUtil.formatJSON( JSONData ) );
+		JSONService.writeJSONFile( getDescriptorPath( arguments.directory ), JSONData );
 	}
 
 	/**

--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -195,7 +195,7 @@ component accessors="true" singleton {
 	function start(
 		Struct serverProps
 	){
-		
+
 		var job = wirebox.getInstance( 'interactiveJob' );
 		job.start( 'Starting Server', 10 );
 
@@ -288,16 +288,16 @@ component accessors="true" singleton {
 					serverProps.name = newName;
 					var newServerJSONFile = fileSystemUtil.resolvePath( serverProps.directory ?: '' ) & "/server-#serverProps.name#.json";
 					// copy the orig server's server.json file to the new file so it starts with the same properties as the original. lots of alternative ways to do this but the file copy works and is simple
-					if( fileExists( defaultServerConfigFile ) && newServerJSONFile != defaultServerConfigFile ) {					
-						file action='copy' source="#defaultServerConfigFile#" destination="#newServerJSONFile#" mode ='777';	
+					if( fileExists( defaultServerConfigFile ) && newServerJSONFile != defaultServerConfigFile ) {
+						file action='copy' source="#defaultServerConfigFile#" destination="#newServerJSONFile#" mode ='777';
 					}
 					return start( serverProps );
 				}
-					
+
 			} else {
 				job.addWarnLog( 'Overwriting previous server [#serverInfo.name#].' );
 			}
-			
+
 		}
 
 		// *************************************************************************************
@@ -561,22 +561,22 @@ component accessors="true" singleton {
 		serverInfo.SSLEnable 		= serverProps.SSLEnable 		?: serverJSON.web.SSL.enable			?: defaults.web.SSL.enable;
 		serverInfo.HTTPEnable		= serverProps.HTTPEnable 		?: serverJSON.web.HTTP.enable			?: defaults.web.HTTP.enable;
 		serverInfo.SSLPort			= serverProps.SSLPort 			?: serverJSON.web.SSL.port				?: defaults.web.SSL.port;
-		
+
 		serverInfo.AJPEnable 		= serverProps.AJPEnable 		?: serverJSON.web.AJP.enable			?: defaults.web.AJP.enable;
 		serverInfo.AJPPort			= serverProps.AJPPort 			?: serverJSON.web.AJP.port				?: defaults.web.AJP.port;
-		
+
 		// relative certFile in server.json is resolved relative to the server.json
 		if( isDefined( 'serverJSON.web.SSL.certFile' ) ) { serverJSON.web.SSL.certFile = fileSystemUtil.resolvePath( serverJSON.web.SSL.certFile, defaultServerConfigFileDirectory ); }
 		// relative certFile in config setting server defaults is resolved relative to the web root
 		if( len( defaults.web.SSL.certFile ?: '' ) ) { defaults.web.SSL.certFile = fileSystemUtil.resolvePath( defaults.web.SSL.certFile, defaultwebroot ); }
 		serverInfo.SSLCertFile 		= serverProps.SSLCertFile 		?: serverJSON.web.SSL.certFile			?: defaults.web.SSL.certFile;
-		
+
 		// relative keyFile in server.json is resolved relative to the server.json
 		if( isDefined( 'serverJSON.web.SSL.keyFile' ) ) { serverJSON.web.SSL.keyFile = fileSystemUtil.resolvePath( serverJSON.web.SSL.keyFile, defaultServerConfigFileDirectory ); }
 		// relative trayIcon in config setting server defaults is resolved relative to the web root
 		if( len( defaults.web.SSL.keyFile ?: '' ) ) { defaults.web.SSL.keyFile = fileSystemUtil.resolvePath( defaults.web.SSL.keyFile, defaultwebroot ); }
 		serverInfo.SSLKeyFile 		= serverProps.SSLKeyFile 		?: serverJSON.web.SSL.keyFile			?: defaults.web.SSL.keyFile;
-		
+
 		serverInfo.SSLKeyPass 		= serverProps.SSLKeyPass 		?: serverJSON.web.SSL.keyPass			?: defaults.web.SSL.keyPass;
 		serverInfo.rewritesEnable 	= serverProps.rewritesEnable	?: serverJSON.web.rewrites.enable		?: defaults.web.rewrites.enable;
 		serverInfo.rewritesStatusPath = 							   serverJSON.web.rewrites.statusPath	?: defaults.web.rewrites.statusPath;
@@ -588,7 +588,7 @@ component accessors="true" singleton {
 		serverInfo.trayEnable	 	= serverJSON.trayEnable			?: defaults.trayEnable;
 
 		serverInfo.defaultBaseURL = serverInfo.SSLEnable ? 'https://#serverInfo.host#:#serverInfo.SSLPort#' : 'http://#serverInfo.host#:#serverInfo.port#';
-			
+
 		// If there's no open URL, let's create a complete one
 		if( !serverInfo.openbrowserURL.len() ) {
 			serverInfo.openbrowserURL = serverInfo.defaultBaseURL;
@@ -636,7 +636,7 @@ component accessors="true" singleton {
 
 		serverInfo.trayOptions = defaults.trayOptions;
 		serverJSON.trayOptions = serverJSON.trayOptions ?: [];
-		
+
 		// global defaults are relative to web root
 		// TODO: perform this recursivley into "items" sub arrays
 		serverInfo.trayOptions = serverInfo.trayOptions.map( function( item ){
@@ -645,25 +645,25 @@ component accessors="true" singleton {
 			}
 			return item;
 		} );
-		
+
 		// server.json settings are relative to the folder server.json lives
 		// TODO: perform this recursivley into "items" sub arrays
 		serverJSON.trayOptions = serverJSON.trayOptions.map( function( item ){
-			if( item.keyExists( 'image' ) && item.image.len() ) {				
+			if( item.keyExists( 'image' ) && item.image.len() ) {
 				item.image = fileSystemUtil.resolvePath( item.image, defaultServerConfigFileDirectory );
 			}
 			return item;
 		} );
-		
+
 		// Global trayOptions are always added on top of server.json (but don't overwrite)
 		// trayOptions aren't accepted via command params due to no clean way to provide them
 		serverInfo.trayOptions.append( serverJSON.trayOptions, true );
 
 		serverInfo.accessLogEnable	= serverJSON.web.accessLogEnable ?: defaults.web.accessLogEnable;
 		serverInfo.GZIPEnable	= serverJSON.web.GZIPEnable ?: defaults.web.GZIPEnable;
-		 
+
 		serverInfo.rewriteslogEnable = serverJSON.web.rewrites.logEnable ?: defaults.web.rewrites.logEnable;
-				
+
 		// Global defauls are always added on top of whatever is specified by the user or server.json
 		serverInfo.JVMargs			= ( serverProps.JVMargs			?: serverJSON.JVM.args ?: '' ) & ' ' & defaults.JVM.args;
 
@@ -820,12 +820,12 @@ component accessors="true" singleton {
 			var displayServerName = processName;
 			var displayEngineName = 'WAR';
 		}
-		
+
 		// logdir is set above and is different for WARs and CF engines
 		serverInfo.consolelogPath = serverInfo.logdir & '/server.out.txt';
 		serverInfo.accessLogPath = serverInfo.logDir & '/access.txt';
 		serverInfo.rewritesLogPath = serverInfo.logDir & '/rewrites.txt';
-		 
+
 		// Find the correct tray icon for this server
 		if( !len( serverInfo.trayIcon ) ) {
 			var iconSize = fileSystemUtil.isWindows() ? '-32px' : '';
@@ -867,10 +867,10 @@ component accessors="true" singleton {
 			var lastFolder = appFileSystemPathDisplay.listLast( '/' );
 			var middleStuff = appFileSystemPathDisplay.listDeleteAt( pathLength, '/' ).listDeleteAt( 1, '/' );
 			// Ignoring slashes here.  Doesn't need to be exact.
-			var leftOverLen = max( 50 - (firstFolder.len() + lastFolder.len() ), 1 ); 
+			var leftOverLen = max( 50 - (firstFolder.len() + lastFolder.len() ), 1 );
 			// This will shorten the path to C:/firstfolder/somes/tuff.../lastFolder/
 			// with a final result that is close to 50 characters
-			appFileSystemPathDisplay = firstFolder & '/' & middleStuff.left( leftOverLen ) & '.../' & lastFolder & '/';	 
+			appFileSystemPathDisplay = firstFolder & '/' & middleStuff.left( leftOverLen ) & '.../' & lastFolder & '/';
 		}
 
 		serverInfo.trayOptions.prepend(
@@ -900,11 +900,11 @@ component accessors="true" singleton {
 		openItems.prepend( { 'label':'Site Home', 'action':'openbrowser', 'url': serverInfo.openbrowserURL, 'image' : expandPath('/commandbox/system/config/server-icons/home.png' ) } );
 
 		openItems.prepend( { "label" : "File System", "hotkey" : "B", "action" : "openfilesystem", "path" : serverInfo.appFileSystemPath, "image" : expandPath('/commandbox/system/config/server-icons/folder.png' ) } );
-		
+
 		serverInfo.trayOptions.prepend( { 'label':'Open...', 'items': openItems, "image" : expandPath('/commandbox/system/config/server-icons/open.png' ) } );
 
 		// serverInfo.trayOptions.prepend( { 'label' : 'Restart Server', 'hotkey':'R', 'action' : 'restartserver', 'image': expandPath('/commandbox/system/config/server-icons/home.png' ) } );
-	
+
 		serverInfo.trayOptions.prepend( { 'label':'Stop Server', 'action':'stopserver', 'image' : expandPath('/commandbox/system/config/server-icons/stop.png' ) } );
 
 	    // This is due to a bug in RunWar not creating the right directory for the logs
@@ -974,7 +974,7 @@ component accessors="true" singleton {
 		 	.append( '--host' ).append( serverInfo.host )
 		 	.append( '--stop-port' ).append( serverInfo.stopsocket )
 		 	.append( '--processname' ).append( processName )
-		 	.append( '--log-dir' ).append( serverInfo.logDir )		 	
+		 	.append( '--log-dir' ).append( serverInfo.logDir )
 		 	.append( '--server-name' ).append( serverInfo.name )
 		 	.append( '--tray-icon' ).append( serverInfo.trayIcon )
 		 	.append( '--tray-config' ).append( trayOptionsPath )
@@ -990,7 +990,7 @@ component accessors="true" singleton {
 			// Debug is getting turned on any time I include the --debug flag regardless of whether it's true or false.
 			args.append( '--debug' ).append( serverInfo.debug );
 		}
-		
+
 		if( len( serverInfo.restMappings ) ) {
 			args.append( '--servlet-rest-mappings' ).append( serverInfo.restMappings );
 		} else {
@@ -1017,17 +1017,17 @@ component accessors="true" singleton {
 			 	.append( '--logaccess-dir' ).append( serverInfo.logDir );
 		}
 
-		
+
 		if( serverInfo.rewritesLogEnable ) {
 			args.append( '--urlrewrite-log' ).append( serverInfo.rewritesLogPath );
 		}
-		 
+
 		/* 	.append( '--logrequests-enable' ).append( true )
 		 	.append( '--logrequests-basename' ).append( 'request' )
 		 	.append( '--logrequests-dir' ).append( serverInfo.logDir )
 		 	*/
-		
-		
+
+
 	 	if( len( CFEngineName ) ) {
 	 		 args.append( '--cfengine-name' ).append( CFEngineName );
 	 	}
@@ -1071,17 +1071,17 @@ component accessors="true" singleton {
 			.append( '--http-enable' ).append( serverInfo.HTTPEnable )
 			.append( '--ssl-enable' ).append( serverInfo.SSLEnable )
 			.append( '--ajp-enable' ).append( serverInfo.AJPEnable );
-				
-				
+
+
 		if( serverInfo.HTTPEnable || serverInfo.SSLEnable ) {
 			args
 			 	.append( '--open-browser' ).append( serverInfo.openbrowser )
-			 	.append( '--open-url' ).append( serverInfo.openbrowserURL );	
+			 	.append( '--open-url' ).append( serverInfo.openbrowserURL );
 		} else {
-			args.append( '--open-browser' ).append( false );			
+			args.append( '--open-browser' ).append( false );
 		}
-		 	
-		 	
+
+
 		// Send HTTP port if it's enabled
 		if( serverInfo.HTTPEnable ){
 			args.append( '--port' ).append( serverInfo.port )
@@ -1096,7 +1096,7 @@ component accessors="true" singleton {
 		if( serverInfo.AJPEnable ){
 			args.append( '--ajp-port' ).append( serverInfo.AJPPort );
 		}
-		
+
 		// Send SSL cert info if SSL is enabled and there's cert info
 		if( serverInfo.SSLEnable && serverInfo.SSLCertFile.len() ) {
 			args
@@ -1148,7 +1148,7 @@ component accessors="true" singleton {
 	    var processBuilder = createObject( "java", "java.lang.ProcessBuilder" );
 	    // Pass array of tokens comprised of command plus arguments
 	    args.prepend( serverInfo.javaHome );
-	    
+
 	    // In *nix OS's we need to separate the server process from the CLI process
 	    // so SIGINTs from Ctrl-C won't also kill previously started servers
 	    if( !fileSystemUtil.isWindows() && background ) {
@@ -1166,7 +1166,7 @@ component accessors="true" singleton {
 			var cleanedArgs = cr & '    ' & trim( reReplaceNoCase( args.toList( ' ' ), ' (-|"-)', cr & '    \1', 'all' ) );
 			job.addLog("Server start command: #cleanedargs#");
 	    }
-	    
+
 	    processBuilder.init( args );
 	    // Conjoin standard error and output for convenience.
 	    processBuilder.redirectErrorStream( true );
@@ -1175,17 +1175,17 @@ component accessors="true" singleton {
 
 		// She'll be coming 'round the mountain when she comes...
 		job.addWarnLog( "The server for #serverInfo.webroot# is starting on #serverInfo.openbrowserURL# ..." );
-	    
+
 	    job.complete( serverInfo.debug );
 	    consoleLogger.debug( '.' );
-	    
+
 		// If the user is running a one-off command to start a server or specified the debug flag, stream the output and wait until it's finished starting.
 		var interactiveStart = ( shell.getShellType() == 'command' || serverInfo.debug || !background );
 
 		// A reference to the current thread so the thread we're about to spin up can access it.
 		// This may be available as parent thread or something.
 		var thisThread = createObject( 'java', 'java.lang.Thread' ).currentThread();
-		variables.waitingOnConsoleStart = false; 
+		variables.waitingOnConsoleStart = false;
 		// Spin up a thread to capture the standard out and error from the server
 		thread name="#threadName#" interactiveStart=interactiveStart serverInfo=serverInfo args=args startTimeout=serverInfo.startTimeout parentThread=thisThread {
 			try{
@@ -1203,12 +1203,12 @@ component accessors="true" singleton {
 
 				var line = bufferedReader.readLine();
 				while( !isNull( line ) ){
-						
+
 					// Log messages from the CF engine or app code writing direclty to std/err out strip off "runwar.context" but leave color coded severity
 					// Ex:
 					// [INFO ] runwar.context: 04/11 15:47:10 INFO Starting Flex 1.5 CF Edition
 					line = reReplaceNoCase( line, '^(#chr( 27 )#\[m\[[^]]*])( runwar\.context: )(.*)', '\1 \3' );
-					
+
 					// Log messages from runwar itself, simplify the logging category to just "Runwar:" and leave color coded severity
 					// Ex:
 					// [DEBUG] runwar.config: Enabling Proxy Peer Address handling
@@ -1231,7 +1231,7 @@ component accessors="true" singleton {
 							.line( line )
 							.toConsole();
 					}
-					
+
 					line = bufferedReader.readLine();
 				} // End of inputStream
 
@@ -1327,7 +1327,7 @@ component accessors="true" singleton {
 	function resolveServerDetails(
 		required struct serverProps
 	) {
-		
+
 		var job = wirebox.getInstance( 'interactiveJob' );
 		var locDebug = serverProps.debug ?: false;
 
@@ -1429,7 +1429,7 @@ component accessors="true" singleton {
 			// Get server descriptor again
 		    if( locDebug ) { consoleLogger.debug("Switching to the last-used server JSON file for this server: #serverInfo.serverConfigFile#"); }
 			var serverJSON_rawSystemSettings = readServerJSON( serverInfo.serverConfigFile );
-			var serverJSON = systemSettings.expandDeepSystemSettings( duplicate( serverJSON_rawSystemSettings ) );			
+			var serverJSON = systemSettings.expandDeepSystemSettings( duplicate( serverJSON_rawSystemSettings ) );
 			defaultServerConfigFile = serverInfo.serverConfigFile;
 
 			// Now that we changed server JSONs, we need to recalculate the webroot.
@@ -1452,7 +1452,7 @@ component accessors="true" singleton {
 
 		// By now we've figured out the name, webroot, and serverConfigFile for this server.
 		// Also return the serverInfo of the last values the server was started with (if ever)
-		// and the serverJSON setting for the server, if they exist.		
+		// and the serverJSON setting for the server, if they exist.
 		return {
 			defaultName : defaultName,
 			defaultwebroot : defaultwebroot,
@@ -1560,7 +1560,7 @@ component accessors="true" singleton {
 			// Same as above-- the IP address/host isn't bound to any local adapters.  Probably a host file entry went missing.
 			throw( "The IP address that [#arguments.host#] resovles to can't be bound.  If you ping it, does it point to a local network adapter?", 'serverException', e.message & ' ' & e.detail );
 		}
-			
+
 		return portNumber;
 	}
 
@@ -1603,7 +1603,7 @@ component accessors="true" singleton {
 			portToCheck = serverInfo.SSLPort;
 		} else if( serverInfo.AJPEnable ) {
 			portToCheck = serverInfo.AJPPort;
-		} 
+		}
 		return !isPortAvailable( serverInfo.host, portToCheck );
 	}
 
@@ -1800,7 +1800,7 @@ component accessors="true" singleton {
 	* @webroot.hint root directory for served content
  	**/
 	struct function getServerInfo( required webroot , required name){
-		var servers 	= getServers();	
+		var servers 	= getServers();
 		var normalizedWebroot = normalizeWebroot( arguments.webroot );
 		var webrootHash = hash( normalizedWebroot & ucase( arguments.name ) );
 		var statusInfo 	= {};
@@ -1893,7 +1893,7 @@ component accessors="true" singleton {
 			'aliases'			: {},
 			'errorPages'		: {},
 			'accessLogEnable'	: false,
-			'GZIPEnable'		: true,			
+			'GZIPEnable'		: true,
 			'rewritesLogEnable'	: false,
 			'trayOptions'		: {},
 			'trayEnable'		: true,

--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -1926,16 +1926,7 @@ component accessors="true" singleton {
 	* Save a server.json file.
 	*/
 	function saveServerJSON( required string configFilePath, required struct data ) {
-		var oldJSON = '';
-		if( fileExists( arguments.configFilePath ) ) {
-			oldJSON = fileRead( arguments.configFilePath );
-		}
-		var newJSON = formatterUtil.formatJSON( serializeJSON( arguments.data ) );
-		// Try to prevent bunping the date modified for no reason
-		if( oldJSON != newJSON ) {
-	    	directoryCreate( getDirectoryFromPath( arguments.configFilePath ), true, true );
-			fileWrite( arguments.configFilePath, newJSON );
-		}
+		JSONService.writeJSONFile( path = configFilePath, json = data, writeOnChangeOnly = true );
 	}
 
 	/**

--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -1926,7 +1926,7 @@ component accessors="true" singleton {
 	* Save a server.json file.
 	*/
 	function saveServerJSON( required string configFilePath, required struct data ) {
-		JSONService.writeJSONFile( path = configFilePath, json = data, writeOnChangeOnly = true );
+		JSONService.writeJSONFile( configFilePath, data );
 	}
 
 	/**

--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -1650,7 +1650,7 @@ component accessors="true" singleton {
 	 * @servers.hint struct of serverInfos
  	 **/
 	ServerService function setServers( required Struct servers ){
-		fileSystemUtil.lockingfileWrite( serverConfig, formatterUtil.formatJson( serializeJSON( servers ) ) );
+		JSONService.writeJSONFile( serverConfig, servers, true );
 		return this;
 	}
 

--- a/src/cfml/system/util/Formatter.cfc
+++ b/src/cfml/system/util/Formatter.cfc
@@ -246,12 +246,15 @@ component singleton {
 	/**
 	 * Pretty JSON
 	 * @json A string containing JSON, or a complex value that can be serialized to JSON
- 	 **/
-	public function formatJson( json, indent, lineEnding ) {
+	 **/
+	public function formatJson( json, indent, lineEnding, spaceAfterColon, sortKeys ) {
 		// This is an external lib now.  Leaving here for backwards compat.
-        if ( isNull( arguments.sortKeys ) ) {
-            arguments.sortKeys = configService.getSetting( 'JSONPrettyPrint.sortKeys', 'textnocase' );
-        }
+		if ( isNull( arguments.spaceAfterColon ) ) {
+			arguments.spaceAfterColon = configService.getSetting( 'JSONPrettyPrint.spaceAfterColon', false );
+		}
+		if ( isNull( arguments.sortKeys ) ) {
+			arguments.sortKeys = configService.getSetting( 'JSONPrettyPrint.sortKeys', 'textnocase' );
+		}
 		return JSONPrettyPrint.formatJSON( argumentCollection=arguments );
 	}
 }

--- a/src/cfml/system/util/Formatter.cfc
+++ b/src/cfml/system/util/Formatter.cfc
@@ -249,12 +249,10 @@ component singleton {
 	 **/
 	public function formatJson( json, indent, lineEnding, spaceAfterColon, sortKeys ) {
 		// This is an external lib now.  Leaving here for backwards compat.
-		if ( isNull( arguments.spaceAfterColon ) ) {
-			arguments.spaceAfterColon = configService.getSetting( 'JSONPrettyPrint.spaceAfterColon', false );
-		}
+		structAppend( arguments, configService.getSetting( 'json', { } ), false );
 		if ( isNull( arguments.sortKeys ) ) {
-			arguments.sortKeys = configService.getSetting( 'JSONPrettyPrint.sortKeys', 'textnocase' );
+			arguments.sortKeys = 'textnocase';
 		}
-		return JSONPrettyPrint.formatJSON( argumentCollection=arguments );
+		return JSONPrettyPrint.formatJSON( argumentCollection = arguments );
 	}
 }

--- a/src/cfml/system/util/Formatter.cfc
+++ b/src/cfml/system/util/Formatter.cfc
@@ -11,6 +11,7 @@
 component singleton {
 
 	// DI
+    property name="configService" inject="ConfigService";
 	property name="shell" inject="shell";
 	property name="print" inject="print";
 	property name="JSONPrettyPrint" inject="provider:JSONPrettyPrint";
@@ -127,7 +128,7 @@ component singleton {
     	}
     	return text;
 	}
-	
+
 
 	/**
 	 * Converts markdown into ANSI text
@@ -139,12 +140,12 @@ component singleton {
 		var codeBlockContents = '';
 		var formattedText = [];
 		var previousLineNeedsPadding = false;
-		
+
     	if( len( trim( text ) ) == 0 ) {
     		return "";
     	}
-    	
-		// Turn all line endings into LF or it will be impossible to 
+
+		// Turn all line endings into LF or it will be impossible to
 		// parse the lines and keep empty rows.
 		text = replace( text, CRLF, LF, 'all' );
 		text = replace( text, CR, LF, 'all' );
@@ -152,20 +153,20 @@ component singleton {
 		text
 			.listToArray( LF, true )
 			.each( function( line ) {
-				
-				
+
+
 				// Detect the start of code blocks
 				if( line.trim().startsWith( '```' ) && !inCodeBlock ) {
 					inCodeBlock=true;
 					return;
 				}
-				
+
 				// If we're already in a code block
 				if( inCodeBlock ) {
 					// Is this the end of the code block?
 					if( line.trim().startsWith( '```' ) ) {
 						inCodeBlock = false;
-						
+
 						// Turn code block into array,
 						var codeArray = codeBlockContents
 							.listToArray( LF, true )
@@ -175,18 +176,18 @@ component singleton {
 							} )
 							// pad before and after
 							.prepend( '' )
-						
+
 						// Find the longest line of code
 						var longestLine = codeArray.reduce( function( prev, codeLine) {
 							return max( prev, codeLine.len() );
 						}, 0 ) + 2;
-						
+
 						// pad each row so the lengths are all the same
 						codeArray = codeArray.map( function( codeLine ) {
 							return '  ' & print.indentedBlackOnWhite( codeLine & repeatString( ' ', longestLine-codeLine.len() ) );
 						} );
-						
-						// Turn array back into string with 
+
+						// Turn array back into string with
 						line = LF & codeArray.toList( LF ) & print.text( '', additionalFormatting, true );
 						codeBlockContents = '';
 						previousLineNeedsPadding = true;
@@ -195,59 +196,62 @@ component singleton {
 					return;
 					}
 				} else {
-					
+
 					// Add extra line after heading and code blocks if it's not already there
 					if( previousLineNeedsPadding && !line.trim() == '' ) {
 						formattedText.append( '' );
 					}
-					
+
 					// Let the next interation know we just had a section heading
 					if( reFindNoCase( '^##{1,4}\s*(.*)$', line ) ) {
 						previousLineNeedsPadding = true;
 					} else {
 						previousLineNeedsPadding = false;
 					}
-					
+
 					// Convert section headings
 					line = reReplaceNoCase( line, '^##{1,4}\s*(.*)$', print.bold( LF & '\1' ) & print.text( '', additionalFormatting, true ) );
-					
+
 					// Convert inline blocks
 					line = reReplaceNoCase( line, '`([^`]*)`', print.bold( '\1' ) & print.text( '', additionalFormatting, true ), 'all' );
-					
+
 					// Convert bold blocks
 					line = reReplaceNoCase( line, '\*\*([^`]*)\*\*', print.bold( '\1' ) & print.text( '', additionalFormatting, true ), 'all' );
-					
+
 					// Convert italics blocks
 					line = reReplaceNoCase( line, '`([^`]*)`', print.bold( '\1' ) & print.text( '', additionalFormatting, true ), 'all' );
-					
+
 					// Indent lists
 					if( line.startsWith( '* ' ) || line.startsWith( '- ' ) ) {
-						line = '  ' & line;	
+						line = '  ' & line;
 					}
-					
+
 					// Horizontal Rule
 					if( line.trim().reFind( '^([-]{3,}|[_]{3,}|[*]{3,})$' ) ) {
 						// Repeat across 75% of the terminal width
 						line = repeatString( '_', int( shell.getTermWidth() * .75 ) );
-						previousLineNeedsPadding = true; 
+						previousLineNeedsPadding = true;
 					}
-					
+
 				}
-				
+
 				formattedText.append( line );
 			} );
-			
-			
+
+
 		return formattedText.toList( LF );
 
 	}
-	
+
 	/**
 	 * Pretty JSON
 	 * @json A string containing JSON, or a complex value that can be serialized to JSON
  	 **/
 	public function formatJson( json, indent, lineEnding ) {
 		// This is an external lib now.  Leaving here for backwards compat.
+        if ( isNull( arguments.sortKeys ) ) {
+            arguments.sortKeys = configService.getSetting( 'JSONPrettyPrint.sortKeys', 'textnocase' );
+        }
 		return JSONPrettyPrint.formatJSON( argumentCollection=arguments );
 	}
 }

--- a/src/cfml/system/util/Formatter.cfc
+++ b/src/cfml/system/util/Formatter.cfc
@@ -250,9 +250,6 @@ component singleton {
 	public function formatJson( json, indent, lineEnding, spaceAfterColon, sortKeys ) {
 		// This is an external lib now.  Leaving here for backwards compat.
 		structAppend( arguments, configService.getSetting( 'json', { } ), false );
-		if ( isNull( arguments.sortKeys ) ) {
-			arguments.sortKeys = 'textnocase';
-		}
 		return JSONPrettyPrint.formatJSON( argumentCollection = arguments );
 	}
 }

--- a/src/cfml/system/util/REPLParser.cfc
+++ b/src/cfml/system/util/REPLParser.cfc
@@ -121,7 +121,7 @@ component accessors="true" singleton {
 			return '[Object #getMetaData( result ).name#]';
 		// Serializable types
 		} else if( isArray( result ) || isStruct( result ) || isQuery( result ) ) {
-			return formatterUtil.formatJson( serializeJson( result ) );
+			return formatterUtil.formatJson( result );
 		// Yeah, I give up
 		} else {
 			return '[#result.getClass().getName()#]';


### PR DESCRIPTION
I added two arguments to `formatterUtil.formatJson()`: `spaceAfterColon` and `sortKeys`. `sortKeys` is currently defaulted to `"textnocase"`, which means that all calls to the formatter for displaying JSON to the screen will display sorted JSON by default now (not sure if that is what you wanted). I added checks for config settings of `JSONPrettyPrint.spaceAfterColon` and `JSONPrettyPrint.sortKeys` to the formatter - if those are set they will always be used. So to turn off the JSON sorting of keys you could set  `JSONPrettyPrint.sortKeys=''`. (I was not sure if `JSONPrettyPrint` was a good namespace for the settings?)

I moved the JSON file writes into the JSONService - if you have explicitly set `JSONPrettyPrint.sortKeys` in your settings it will always use that, but if not, it will perform a file read (when the file exists) and check to see what the current state of the file is - if it looks sorted (`textnocase` currently) or it can't tell, it will sort the output, otherwise it will not. The check itself is pretty basic right now, but I can confirm that it does work, such as it is, for my `box.json` files and `server.json` files.

I removed a number of calls to `serializeJSON()` that were used right before calling `formatJson()` since the formatter on Lucee 5 will now use the CFML directly to write out the JSON.

In a couple of places (e.g. `ServerService.cfc`), I committed a bunch of whitespace trimming. I see it somewhat obscures the actual changes, sorry. In `ServerService` for instance I only _really_ changed `setServers` and `saveServerJSON`.