### PR TITLE
Recursively check JSON files for sorting

### DIFF
--- a/src/cfml/system/services/JSONService.cfc
+++ b/src/cfml/system/services/JSONService.cfc
@@ -254,12 +254,22 @@ component accessors="true" singleton {
 			json = deserializeJSON( json );
 		}
 
-		// simple check - are top level keys sorted, default to true if we can't tell
-		if ( isStruct( json ) ) {
-			return json.keyList() == json.keyArray().sort( sortKeys ).toList();
+		var isSorted = function( obj ) {
+			if ( isStruct( obj ) ) {
+				if ( obj.keyList() != obj.keyArray().sort( sortKeys ).toList() ) {
+					return false;
+				}
+				return obj.every( ( k, v ) => isSorted( v ) );
+			}
+
+			if ( isArray( obj ) ) {
+				return obj.every( isSorted );
+			}
+
+			return true;
 		}
 
-		return true;
+		return isSorted( json );
 	}
 
 }


### PR DESCRIPTION
Since our use case is checking JSON files on disk, I just let everything that is not a struct or array return `true`. We could add that `deserializeJSON(serializeJSON())` trick here, but I am not sure what it would even mean in those cases? Speed wise, this check takes about 40-50ms to run through a 1.5MB servers.json file. Obviously it could be shorter than that since it should abort as soon it finds something unsorted. It seems worth it to me to keep files intact that are already on disk.