### PR TITLE
Coldbox watch reinit

### DIFF
--- a/src/cfml/system/modules_app/coldbox-commands/commands/coldbox/watch-reinit.cfc
+++ b/src/cfml/system/modules_app/coldbox-commands/commands/coldbox/watch-reinit.cfc
@@ -5,20 +5,19 @@
  * coldbox watch-reinit
  * {code}
  *
- * In order for this command to work, you need to have started your server and configured the
- * URL to the test runner in your box.json.
+ * In order for this command to work, you need to have started your server.
  *
  * {code}
  * server start
  * coldbox watch-reinit
  * {code}
  *
- * If you need more control over what tests run and their output, you can set additional options in your box.json
- * which will be picked up automatically by "testbox run" when it fires.
+ * If you need more control over what files reinit the framework, you can set additional options in your box.json
+ * which will be picked up automatically by "coldbox watch-reinit" when it fires.
  *
  * {code}
  * package set reinitWatchDelay=1000
- * package set reinitWatchPaths=["config/**.cfc","handler/**.cfc","models/**.cfc"]
+ * package set reinitWatchPaths= "config/**.cfc,handlers/**.cfc,models/**.cfc"
  * {code}
  *
  * This command will run in the foreground until you stop it.  When you are ready to shut down the watcher, press Ctrl+C.

--- a/src/cfml/system/modules_app/coldbox-commands/commands/coldbox/watch-reinit.cfc
+++ b/src/cfml/system/modules_app/coldbox-commands/commands/coldbox/watch-reinit.cfc
@@ -1,0 +1,80 @@
+/**
+ * Watch the files in a directory and run the default Coldbox reinit on any file change.
+ *
+ * {code}
+ * coldbox watch-reinit
+ * {code}
+ *
+ * In order for this command to work, you need to have started your server and configured the
+ * URL to the test runner in your box.json.
+ *
+ * {code}
+ * server start
+ * coldbox watch-reinit
+ * {code}
+ *
+ * If you need more control over what tests run and their output, you can set additional options in your box.json
+ * which will be picked up automatically by "testbox run" when it fires.
+ *
+ * {code}
+ * package set reinitWatchDelay=1000
+ * package set reinitWatchPaths=["config/**.cfc","handler/**.cfc","models/**.cfc"]
+ * {code}
+ *
+ * This command will run in the foreground until you stop it.  When you are ready to shut down the watcher, press Ctrl+C.
+ *
+ **/
+component {
+
+	// DI
+	property name="packageService" 	inject="PackageService";
+
+	variables.WATCH_DELAY 	= 500;
+	variables.PATHS 		= "config/**.cfc,handlers/**.cfc,models/**.cfc";
+
+	/**
+	 * @paths Command delimited list of file globbing paths to watch relative to the working directory, defaults to **.cfc
+	 * @delay How may milliseconds to wait before polling for changes, defaults to 500 ms
+	 **/
+	function run(
+		string paths,
+	 	number delay
+	) {
+
+		// Get watch options from package descriptor
+		var boxOptions = packageService.readPackageDescriptor( getCWD() );
+
+		var getOptionsWatchers = function(){
+			// Return to List
+			if( boxOptions.keyExists( "reinitWatchPaths" ) && boxOptions.reinitWatchPaths.len() ){
+				return ( isArray( boxOptions.reinitWatchPaths ) ? boxOptions.reinitWatchPaths.toList() : boxOptions.reinitWatchPaths );
+			}
+			// should return null if not found
+			return;
+		}
+
+		// Determine watching patterns, either from arguments or boxoptions or defaults
+		var globbingPaths = arguments.paths ?: getOptionsWatchers() ?: variables.PATHS;
+		// handle non numberic config and put a floor of 150ms
+		var delayMs = max( val( arguments.delay ?: boxOptions.reinitWatchDelay ?: variables.WATCH_DELAY ), 150 );
+
+		// Tabula rasa
+		command( 'cls' ).run();
+
+		// Start watcher
+		watch()
+			.paths( globbingPaths.listToArray() )
+			.inDirectory( getCWD() )
+			.withDelay( delayMs )
+			.onChange( function( changeData ) {
+
+				print.line( formatterUtil.formatJSON(changeData) ).toConsole();
+
+				command( 'coldbox reinit' ).run();
+
+
+			} )
+			.start();
+	}
+
+}

--- a/src/cfml/system/util/Watcher.cfc
+++ b/src/cfml/system/util/Watcher.cfc
@@ -27,6 +27,8 @@ component accessors=true {
 
 	// Properties
 	property name='changeHash'			type='string';
+	property name='fileIndex'			type='struct';
+	property name='changeData'			type='struct';
 	property name='watcherRun'			type='boolean';
 	property name='pathsToWatch'		type='array';
 	property name='changeUDF'			type='function';
@@ -104,7 +106,7 @@ component accessors=true {
 
 							// Fire onChange listener
 							var thisChangeUDF = getChangeUDF();
-							thisChangeUDF();
+							thisChangeUDF( getChangeData() );
 
 						} else {
 							// Sleep and test again.
@@ -165,7 +167,7 @@ component accessors=true {
 			setWatcherRun( false );
 			// Wait until the thread finishes its last draw
 			thread action="terminate" name=threadName;
-			
+
 		// user wants to exit the shell, they've pressed Ctrl-D
 		} catch ( org.jline.reader.EndOfFileException e ) {
 
@@ -179,7 +181,7 @@ component accessors=true {
 			// Wait until the thread finishes its last draw
 			thread action="terminate" name=threadName;
 			shell.setKeepRunning( false );
-			
+
 		// Something horrible went wrong
 		} catch ( any e ) {
 			// make sure the thread exits
@@ -220,16 +222,46 @@ component accessors=true {
 			},
 			"DateLastModified desc" );
 
+			var fileIndex = {};
+			for(file in fileListing){
+				var thisPath = replacenocase( file.directory & '/' & file.name, thisBaseDir, "" );
+				fileIndex[thisPath] = file.DATELASTMODIFIED;
+			}
+
+			setFileIndex( fileIndex );
+
 		var directoryHash = hash( serializeJSON( fileListing ) );
 
 		return directoryHash;
 	}
 
 	private function changeDetected() {
+		var previousWatchList = getFileIndex();
 		var newHash = calculateHashes();
+
 		if( getChangeHash() == newHash ){
 			return false;
 		}
+		var currentWatchList = getFileIndex();
+
+		var changes = {'added':[],'removed':[],'changed':[]};
+
+		//loop over new array and look for changes and adds
+		currentWatchList.each(function(filePath,fileDate){
+			//if found check for date change, else new file
+			if(structKeyExists(previousWatchList,filePath)){
+				if(previousWatchList[filePath] != fileDate) changes.changed.append(filePath);
+			} else {
+				changes.added.append(filePath);
+			}
+		})
+
+		//look for deleted files that no longer exist in the list
+		previousWatchList.each(function(filePath,fileDate){
+			if(!structKeyExists(currentWatchList, filePath)) changes.removed.append(filePath);
+		})
+
+		setChangeData( changes );
 		setChangeHash( newHash );
 		return true;
 	}


### PR DESCRIPTION
A CommandBox command that allows you to have a watcher looking for changes to watched folders and reinitialize your ColdBox framework. The specific path is configurable in your box.json via "reinitWatchPaths". Also with an addition to the CommandBox watcher to return the actual file changes that happened on a change event