### PR TITLE
Include mapping-tag in rewrite exclusion list

### DIFF
--- a/src/cfml/system/config/urlrewrite.xml
+++ b/src/cfml/system/config/urlrewrite.xml
@@ -4,7 +4,7 @@
 	<rule>
 		<note>Generic Front-Controller URLs</note>
 		<!-- These are paths that don't exist on disk, but shouldn't get rewritten since the CF engine treats them special. -->
-		<condition type="request-uri" operator="notequal">^/(flex2gateway|flashservices/gateway|messagebroker|lucee|rest|cfide|CFIDE|cfformgateway|jrunscripts|cf_scripts|CFFileServlet)/.*</condition>
+		<condition type="request-uri" operator="notequal">^/(flex2gateway|flashservices/gateway|messagebroker|lucee|rest|cfide|CFIDE|cfformgateway|jrunscripts|cf_scripts|mapping-tag|CFFileServlet)/.*</condition>
 		<!-- This is a special URL that can be enabled with debugging -->
 		<condition type="request-uri" operator="notequal">^/tuckey-status</condition>
 		<!-- Used for the Adobe CF 2018 performance monitoring service -->


### PR DESCRIPTION
Lucee reserves this mapping, e.g. https://luceeserver.atlassian.net/browse/LDEV-2055