### PR TITLE
Use file separator specific to OS in Watcher

### DIFF
--- a/src/cfml/system/config/WireBox.cfc
+++ b/src/cfml/system/config/WireBox.cfc
@@ -54,6 +54,7 @@ component extends='wirebox.system.ioc.config.Binder' {
 		var REPLScriptHistoryFile 	= homedir & '/.history-repl-script';
 		var REPLTagHistoryFile 		= homedir & '/.history-repl-tag';
 		var cr						= chr( 10 );
+		var fileSeparator			= system.getProperty( 'file.separator' );
 		var commandLocations		= [
 			// This is where user-installed commands are stored
 			// This is deprecated in favor of modules, but leaving it so 'old' style commands will still load.
@@ -75,6 +76,7 @@ component extends='wirebox.system.ioc.config.Binder' {
 		map( 'REPLScriptHistoryFile@constants' ).toValue( REPLScriptHistoryFile );
 		map( 'REPLTagHistoryFile@constants' ).toValue( REPLTagHistoryFile );
 		map( 'cr@constants' ).toValue( cr );
+		map( 'fileSeparator@constants' ).toValue( fileSeparator );
 		map( 'commandLocations@constants' ).toValue( commandLocations );
 		map( 'ortusArtifactsURL@constants' ).toValue( ortusArtifactsURL );
 		map( 'ortusPRDArtifactsURL@constants' ).toValue( ortusPRDArtifactsURL );

--- a/src/cfml/system/util/Watcher.cfc
+++ b/src/cfml/system/util/Watcher.cfc
@@ -24,6 +24,7 @@ component accessors=true {
 	property name='print'				inject='PrintBuffer';
 	property name='pathPatternMatcher'	inject='provider:pathPatternMatcher@globber';
 	property name='fileSystemUtil'		inject='FileSystem';
+	property name='fileSeparator'		inject='fileSeparator@constants';
 
 	// Properties
 	property name='changeHash'			type='string';
@@ -228,7 +229,7 @@ component accessors=true {
 
 			var fileIndex = {};
 			for(file in fileListing){
-				var thisPath = replacenocase( file.directory & '/' & file.name, thisBaseDir, "" );
+				var thisPath = replacenocase( file.directory & fileSeparator & file.name, thisBaseDir, "" );
 				fileIndex[thisPath] = file.DATELASTMODIFIED;
 			}
 


### PR DESCRIPTION
As you can see I added a `fileSeparator` to the constants - not sure if you want that approach or not.