### PR TITLE
COMMANDBOX-996

### DIFF
--- a/src/cfml/system/util/jline/CommandCompletor.cfc
+++ b/src/cfml/system/util/jline/CommandCompletor.cfc
@@ -65,6 +65,12 @@ component singleton {
 
 			}
 
+			// special handing for run command - suggest path completions for last token
+			if ( commandInfo.commandstring == 'run' ) {
+				pathCompletion( parsedLine.word(), candidates, true, '', false );
+				return;
+			}
+
 			// If stuff was typed and it's an exact match to a command part
 			if( matchedToHere == len( buffer ) && len( buffer ) ) {
 				// Suggest a trailing space


### PR DESCRIPTION
Support path completions on last token for run command. I decided to go for the minimal change - so this won't affect other command completions, only the run command. 

Note: currently if I have `run _` in the buffer and I hit tab, I will get `command=` as a suggestion. This change will remove that suggestion in that situation, but since that won't actually work for running a command anyways, I decided that was probably ok.