### PR TITLE
Add support for `cd -`

### DIFF
--- a/src/cfml/system/modules_app/system-commands/commands/cd.cfc
+++ b/src/cfml/system/modules_app/system-commands/commands/cd.cfc
@@ -13,25 +13,34 @@
  **/
 component {
 
+	function init() {
+		variables.previousDirectory = '.';
+	}
+
 	/**
 	 * @directory.hint The directory to change to
 	 **/
 	function run( directory="" )  {
 
+		if (arguments.directory == '-') {
+			arguments.directory = variables.previousDirectory;
+		}
+
 		// This will make each directory canonical and absolute
 		arguments.directory = resolvePath( arguments.directory );
 
 		if( !directoryExists( arguments.directory ) ) {
-			
-			// Add a friendly check for someone trying to CD into the root of a UNC network share 
+
+			// Add a friendly check for someone trying to CD into the root of a UNC network share
 			if( arguments.directory.reFind( '^\\\\[^\\/]*[\\/]?$' ) ) {
 				print.boldRedLine( 'The root path of a Windows UNC network path cannot be listed or CD''d into.' )
 					.boldRedLine( 'Try Changing into a shared folder like [#arguments.directory.listAppend( 'shareName', '/' )#]' );
 			}
-			
+
 			return error( "#arguments.directory#: No such file or directory" );
 		}
 
+		variables.previousDirectory = shell.pwd();
 		return shell.cd( arguments.directory );
 	}
 

--- a/src/cfml/system/modules_app/system-commands/commands/cd.cfc
+++ b/src/cfml/system/modules_app/system-commands/commands/cd.cfc
@@ -13,17 +13,13 @@
  **/
 component {
 
-	function init() {
-		variables.previousDirectory = '.';
-	}
-
 	/**
 	 * @directory.hint The directory to change to
 	 **/
 	function run( directory="" )  {
 
 		if (arguments.directory == '-') {
-			arguments.directory = variables.previousDirectory;
+			arguments.directory = systemSettings.getSystemSetting( 'OLDPWD' );
 		}
 
 		// This will make each directory canonical and absolute
@@ -40,7 +36,7 @@ component {
 			return error( "#arguments.directory#: No such file or directory" );
 		}
 
-		variables.previousDirectory = shell.pwd();
+		systemSettings.setSystemSetting( 'OLDPWD', shell.pwd(), true );
 		return shell.cd( arguments.directory );
 	}
 

--- a/src/cfml/system/modules_app/system-commands/commands/cd.cfc
+++ b/src/cfml/system/modules_app/system-commands/commands/cd.cfc
@@ -19,7 +19,7 @@ component {
 	function run( directory="" )  {
 
 		if (arguments.directory == '-') {
-			arguments.directory = systemSettings.getSystemSetting( 'OLDPWD' );
+			arguments.directory = systemSettings.getSystemSetting( 'OLDPWD', shell.pwd() );
 		}
 
 		// This will make each directory canonical and absolute


### PR DESCRIPTION
Other shells I have used (PowerShell, Bash) support `cd -` to jump back to the previous directory and I find that very useful.