### PR TITLE
Add server ID and home to verbose server status

### DIFF
--- a/src/cfml/system/modules_app/server-commands/commands/server/status.cfc
+++ b/src/cfml/system/modules_app/server-commands/commands/server/status.cfc
@@ -153,6 +153,10 @@ component aliases='status,server info' {
 
 				if( arguments.verbose ) {
 
+					print.indentedLine( 'ID: ' & thisServerInfo.id );
+					
+					print.indentedLine( 'Server Home: ' & thisServerInfo.serverHome );
+
 					print.indentedLine( trim( thisServerInfo.statusInfo.command ) );
 					// Put each --arg or -arg on a new line
 					var args = trim( reReplaceNoCase( thisServerInfo.statusInfo.arguments, ' (-|"-)', cr & '\1', 'all' ) );


### PR DESCRIPTION
This might be ok to move up to non-verbose, but I often want to know where my home directory is for the server, and I expect it would be shown when I run `server status`