### PR TITLE
corrected typo in displayed help

### DIFF
--- a/src/cfml/system/modules_app/server-commands/commands/server/start.cfc
+++ b/src/cfml/system/modules_app/server-commands/commands/server/start.cfc
@@ -89,7 +89,7 @@ component aliases="start" {
 	 * @javaHomeDirectory	Path to the JRE home directory containing ./bin/java
 	 * @AJPEnable			Enable AJP
 	 * @AJPPort				AJP Port number
-	 * @javaVersion			Any endpoint ID, such as "java:openjdk11" fromt the Java endpoint 
+	 * @javaVersion			Any endpoint ID, such as "java:openjdk11" from the Java endpoint 
 	 * @javaVersion.optionsUDF	javaVersionComplete
 	 **/
 	function run(


### PR DESCRIPTION
Since the box "server start help" shows the javadocs, we saw that typo ("fromt") at the command line, so worth correcting.