### PR TITLE
Add `--command` flag to server start

### DIFF
--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -337,7 +337,7 @@ component accessors="true" singleton {
 		// Save hand-entered properties in our server.json for next time
 		for( var prop in serverProps ) {
 			// Ignore null props or ones that shouldn't be saved
-			if( isNull( serverProps[ prop ] ) || listFindNoCase( 'saveSettings,serverConfigFile,debug,force,console,trace', prop ) ) {
+			if( isNull( serverProps[ prop ] ) || listFindNoCase( 'saveSettings,serverConfigFile,debug,force,console,trace,command', prop ) ) {
 				continue;
 			}
 	    	var configPath = replace( fileSystemUtil.resolvePath( defaultServerConfigFileDirectory ), '\', '/', 'all' );
@@ -1266,6 +1266,11 @@ component accessors="true" singleton {
 			job.addLog("Server start command: #cleanedargs#");
 	    }
 	    
+		if( serverProps.command ?: false ) {
+			job.complete( serverInfo.debug );
+			return args.map( ( arg ) => '"#arg#"' ).toList( ' ' );
+		}
+
 	    processBuilder.init( args );
 	    
         // incorporate CommandBox environment variables into the process's env


### PR DESCRIPTION
When `--command` is passed to `server start`, return the server start command args without actually executing, so that it can be executed by a shell in the foreground.

This was the simplest change I could come up with that would allow CommandBox to return the command needed to start a server, without actually running it. With this change in place one can do the following in bash (for example):
```bash
$(box server start --console --command savesettings=false | tail -n 1 | xargs)
```
and the following in PowerShell:
```pwsh
iex "& $(box server start --console --command savesettings=false | select -last 1)"
```
In each case (in my testing) the shell successfully starts the server in the foreground, with the same command args that would have been used by CommandBox to start it. The advantage to this obviously being that we can have a foreground start without the CommandBox Java process having to stay running.

I know @bdw429s mentioned there might be another issue involved with  a `--console` start (besides the two Java processes) such that the CommandBox docker images choose to use a background start and `tail`. But absent knowing what that is, I think I would prefer this approach over using a background process and `tail`.

A few notes:
- I chose to just quote every arg to get around the fact that PowerShell is likely to encounter spaces in the args (e.g. filesystem paths) and I wanted to keep things as simple as possible on the CommandBox side. This means that bash has to use `xargs` to unquote things, but that seemed easier to me than custom quoting per OS. Of course, this likely means that if any command arg already contains  a `"` then things will break.
- The one thing that this approach can't account for are any CommandBox system settings that aren't in the shell environment since those are set directly into the Java ProcessBuilder instance:
```
var currentEnv = processBuilder.environment();
currentEnv.putAll( systemSettings.getAllEnvironmentsFlattened() );
```
This isn't an issue for me, but it is something to be aware of. And it won't affect any `server.json` expansion or `.cfconfig.json` variable expansion, since CommandBox is still taking care of those. It just means if you expected a system setting to be in the environment of your running app, that won't work.
- I didn't add a `command` param to the `start` command itself yet, as I was hoping for feedback on this approach first.

I would appreciate thoughts and feedback on this. @mjclemente I am tagging you as well, since I know you too are looking at the docker images.