### PR TITLE
Improve command arg escaping

### DIFF
--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -1268,7 +1268,7 @@ component accessors="true" singleton {
 	    
 		if( serverProps.command ?: false ) {
 			job.complete( serverInfo.debug );
-			return args.map( ( arg ) => '"#arg#"' ).toList( ' ' );
+			return args.map( ( arg ) => toString( arg ).reReplace( '^\-([Dd][^=]+)', '-"\1"' ).replace(' ', '" "', 'all') ).toList( ' ' );
 		}
 
 	    processBuilder.init( args );

--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -1265,10 +1265,10 @@ component accessors="true" singleton {
 			var cleanedArgs = cr & '    ' & trim( reReplaceNoCase( args.toList( ' ' ), ' (-|"-)', cr & '    \1', 'all' ) );
 			job.addLog("Server start command: #cleanedargs#");
 	    }
-	    
-		if( serverProps.command ?: false ) {
+
+		if( serverProps.keyExists( 'command' ) ) {
 			job.complete( serverInfo.debug );
-			return args.map( ( arg ) => toString( arg ).reReplace( '^\-([Dd][^=]+)', '-"\1"' ).replace(' ', '" "', 'all') ).toList( ' ' );
+			return args.map( escapeCommandArgs( serverProps.command ) ).toList( ' ' );
 		}
 
 	    processBuilder.init( args );
@@ -2144,5 +2144,64 @@ component accessors="true" singleton {
 		}
 
 		return props;
+	}
+
+	function escapeCommandArgs( required string targetShell ) {
+		// regex to split a string into quoted and unquoted segments
+		var segmentRegex = function( escapeChar ) {
+			if( !isNull( arguments.escapeChar ) ) {
+				// (?:[^"]|#escapeChar#.)+
+				// match anything that is not a quote or is an escape followed by anything
+				// or
+				// "(?:[^"]|#escapeChar#.)*"
+				// match an opening quote, followed by matching anything that is not
+				// a quote or is an escape followed by anything, followed by a closing quote
+				return '(?:[^"]|#escapeChar#.)+|"(?:[^"]|#escapeChar#.)*"';
+			}
+			// if no escape char, then just match unquoted and quoted sections
+			return '[^"]+|"[^"]*"';
+		};
+
+		var shellEscapes = {
+			bash: function( arg, idx ) {
+				return toString( arg ).reMatch( segmentRegex( '\\' ) ).map( ( segment ) => {
+					if( !segment.startswith( '"' ) ) {
+						segment = segment.replace( ' ', '\ ', 'all' );
+					}
+					return segment;
+				} ).toList( '' );
+			},
+			cmd: function( arg, idx ) {
+				return toString( arg ).reMatch( segmentRegex() ).map( ( segment ) => {
+					if( !segment.startswith( '"' ) and segment.find( ' ' ) ) {
+						segment = '"#segment#"';
+					}
+					if( segment.endswith( '\"' ) ) {
+						// cmd will pass this literally, so we need to escape it for the underlying Java process
+						segment = segment.left( -2 ) & '\\"';
+					}
+					return segment;
+				} ).toList( '' );
+			},
+			pwsh: function( arg, idx ) {
+				return toString( arg ).reMatch( segmentRegex( '`' ) ).map( ( segment ) => {
+					if( !segment.startswith( '"' ) ) {
+						segment = segment.replace( ' ', '` ', 'all' );
+					}
+					// PowerShell needs the `-` in single `-` args escaped when they contain periods
+					// or it will split the argument at the period
+					if( segment.reFind( '^-(?!-)' ) && segment.find( '.' ) ) {
+						segment = '`' & segment;
+					}
+					return segment;
+				} ).toList( '' );
+			}
+		};
+
+		if( !shellEscapes.keyExists( targetShell ) ) {
+			throw( message="Invalid target shell specified. [#targetShell#].", type="commandException");
+		}
+
+		return shellEscapes[ targetShell ];
 	}
 }


### PR DESCRIPTION
This will improve the cross shell compatibility. It won't be perfect, but it is an improvement over quoting args in their entirety. There are two immediate issues that I think have been identified so far:

- Spaces in Windows file paths

This is clearly almost certainly going to be encountered by anyone on Windows. Merely quoting the full path, if it ends in `\`, is not an option for CMD, as we have seen, since it passes the quotes on to the underlying CreateProcess call (more on that below). The escape characters are not shared between CMD and PowerShell, so trying to get a single fully escaped solution for both shells is not possible and we would have to target specific shells in the `--command` output. But I don't think we need to do this if we just quote all spaces individually in each argument. When PowerShell and Bash encounter double quotes they will strip them, which is fine, and CMD will pass them on and then the underlying process will strip them out. This won't address all cases, but it will address the most common and it is better than what I put there in the first place.

- Single dash args cannot contain periods in PowerShell

If you give it `-Djava.prop=foo`, it will split that into two args `-Djava` and `.prop=foo`. My first solution was to quote all the args fully, which is fine for PowerShell, but not for CMD as we saw. So alternately we can can quote after the dash to the `=`: `-"Djava.prop"=foo`. Bash and PowerShell strip these quotes, and CMD passes them on, but they are then stripped by the underlying Java executable and are not an issue (I have tested this).

With these two argument escapes, I can launch the CommandBox generated script from both CMD and PowerShell without issue on Windows, and Bash still works on Linux. There might very well be situations where this is not sufficient, but I think it is definitely an improvement over what I tried first which won't work with CMD.

Below is some of the background on command argument strings that we started digging into last night, which I think indicates why trying to get fully per shell escaped command strings would be challenging. I think what I have here will work fairly well because the command to launch a server process is fairly predictable and we know what in the string is likely to need escaping. Of course, by the same token, we could probably do per shell targeted escaping of only those things we expect to show up and be issues in the command string.

### More Background on argument escaping

I think it is clear from our investigation last night that, in Windows, there are two levels of command line arguments processing happening. First the shell does its processing on the command string entered into it, and then the executable also performs processing on the command string it receives from the shell. In Unix it looks like the args are parsed by the shell and then sent as distinct args to the new process.

This was a helpful link in this regard: http://daviddeley.com/autohotkey/parameters/parameters.htm 

> On nix, the parameters are parsed off by whatever program creates the new process, before the new process is created.

> If you launch a program using the Bash shell command line, The Bash shell is responsible for turning the string provided by the user into the argv[] argument vector which is then passed to the program.

But in Windows, new processes are passed a command string, not a command args array. 

> On Windows, a new program is launched by calling the CreateProcess() API, which takes the command line as a string (the lpComandLine parameter to CreateProcess)

> On Windows, the parameters are parsed off the command line after the new process is created, by the new process. It's considered the responsibility of the newly started application to call the GetCommandLine() API to retrieve the command line string and parse it (possibly using the CommandLineToArgvW() helper function).

And so with PowerShell and CMD.exe you have two levels of processing going on:

> A command line passed to a C/C++ program passes through two parsers:
>
>   The cmd.exe command line parser parses your command & parameters
>   The C/C++ program retrieves the resulting command line and parses off the parameters

So when cmd.exe encounters `"C:\mypath\"` it sends that on to the underlying process as is. That process (Java in our case) then does its own string processing, and interprets the `\"` at the end as an escaped quote so it then continues on to the next quote including everything in between as part of the same arg. PowerShell, on the other hand, strips out the quotes before making the command line string available to the Java Process (it must do some other form of escaping).

_This [link]( https://codewhitesec.blogspot.com/2016/02/java-and-command-line-injections-in-windows.html) was also helpful in discussing how the java ProcessImpl class on Windows handles generating an escaped command string to send to the process it is launching - it looks like it gets complicated.  I poked around a bit to see if we could get a platform specific escaped string out of the ProcessImpl without launching a process, but it looks to me like everything in there is private._

