### PR TITLE
Add server command args interceptor

### DIFF
--- a/src/cfml/system/modules_app/server-commands/ModuleConfig.cfc
+++ b/src/cfml/system/modules_app/server-commands/ModuleConfig.cfc
@@ -7,5 +7,8 @@
 */
 component {
 	function configure() {
+		interceptors = [
+			{ class="#moduleMapping#.interceptors.serverCommandLine" }
+		];
 	}
 }

--- a/src/cfml/system/modules_app/server-commands/interceptors/serverCommandLine.cfc
+++ b/src/cfml/system/modules_app/server-commands/interceptors/serverCommandLine.cfc
@@ -1,0 +1,166 @@
+/**
+ *********************************************************************************
+ * Copyright Since 2014 CommandBox by Ortus Solutions, Corp
+ * www.coldbox.org | www.ortussolutions.com
+ ********************************************************************************
+ *
+ * I am an interceptor that listens for the server start command line arguments
+ * and generates a shell script from them if `scriptFile` is specified.
+ *
+ */
+component {
+
+	property name="job"            inject="interactiveJob";
+	property name="fileSystemUtil" inject="fileSystem";
+	property name="CR"             inject="CR@constants";
+	property name="systemSettings" inject="SystemSettings";
+	property name="print"          inject="PrintBuffer";
+
+	variables.shellScripts = {
+		bash: { ext: 'sh', startlines: [ '##!/bin/bash', '' ], endlines: [] },
+		cmd : { ext: 'bat', startlines: [ '@echo off', 'setlocal' ], endlines: [ 'endlocal' ] },
+		pwsh: { ext: 'ps1', startlines: [], endlines: [] }
+	};
+
+	function onServerCommandLine( struct interceptData ) {
+		if( interceptData.serverProps.keyExists( 'scriptFile' ) ) {
+			if( !shellScripts.keyExists( interceptData.serverProps.scriptFile ) ) {
+				job.addErrorLog(
+					'Invalid target shell specified [#interceptData.serverProps.scriptFile#] for command line shell script. Unable to generate script.'
+				);
+			} else {
+				generateStartScript(
+					interceptData.commandLineArguments,
+					interceptData.serverProps.scriptFile,
+					interceptData.serverProps.scriptFilePath ?: '',
+					interceptData.serverInfo.serverConfigFile
+				);
+			}
+		}
+	}
+
+	private function generateStartScript(
+		required array commandLineArguments,
+		required string targetShell,
+		required string scriptFilePath,
+		required string serverConfigFile
+	) {
+		if( !scriptFilePath.len() ) {
+			scriptFilePath = getFileFromPath( serverConfigFile );
+			if( scriptFilePath.startsWith( 'server' ) ) {
+				scriptFilePath = scriptFilePath.replace( 'server', 'server-start' );
+			} else {
+				scriptFilePath = 'server-start-' & scriptFilePath;
+			}
+			scriptFilePath = scriptFilePath.left( -4 ) & shellScripts[ targetShell ].ext;
+			scriptFilePath = getDirectoryFromPath( serverConfigFile ) & scriptFilePath;
+		}
+
+		scriptFilePath = fileSystemUtil.resolvePath( scriptFilePath );
+
+		var cmdLines = [];
+		cmdLines.append( shellScripts[ targetShell ].startlines, true );
+		cmdLines.append( encodeShellEnv( targetShell ), true );
+		cmdLines.append( encodeShellCmd( commandLineArguments, targetShell ) );
+		cmdLines.append( shellScripts[ targetShell ].endlines, true );
+		fileWrite( scriptFilePath, cmdLines.toList( cr ) & cr );
+
+		job.addLog( 'Start script for shell [#targetShell#] generated at: #scriptFilePath#' );
+	}
+
+	private function encodeShellEnv( required string targetShell ) {
+		var cmdEnv = systemSettings.getAllEnvironmentsFlattened();
+
+		var shellEncoders = {
+			bash:function( result, key, value ) {
+				result.append( 'export #key#="#value.replace( '"', '\"', 'all' )#"' );
+				return result;
+			},
+			cmd:function( result, key, value ) {
+				result.append( 'set #key#=#value#' );
+				return result;
+			},
+			pwsh:function( result, key, value ) {
+				result.append( '$env:#key#="#value.replace( '"', '`"', 'all' )#"' );
+				return result;
+			}
+		};
+
+		return cmdEnv.reduce( shellEncoders[ targetShell ], [] );
+	}
+
+	private function encodeShellCmd( required array args, required string targetShell ) {
+		var shellNewlineEscape = { bash: '\', cmd: '^', pwsh: '`' };
+		var newLineSep         = ' ' & shellNewlineEscape[ targetShell ] & cr & chr( 9 );
+		var reducer            = ( r, a ) => r & ( a.startswith( '-' ) ? newLineSep : ' ' ) & a;
+		return args
+			.map( escapeCommandArgs( targetShell ) )
+			.reduce( reducer, '' )
+			.ltrim();
+	}
+
+	private function escapeCommandArgs( required string targetShell ) {
+		// regex to split a string into quoted and unquoted segments
+		var segmentRegex = function( escapeChar ) {
+			if( !isNull( arguments.escapeChar ) ) {
+				// (?:[^"]|#escapeChar#.)+
+				// match anything that is not a quote or is an escape followed by anything
+				// or
+				// "(?:[^"]|#escapeChar#.)*"
+				// match an opening quote, followed by matching anything that is not
+				// a quote or is an escape followed by anything, followed by a closing quote
+				return '(?:[^"]|#escapeChar#.)+|"(?:[^"]|#escapeChar#.)*"';
+			}
+			// if no escape char, then just match unquoted and quoted sections
+			return '[^"]+|"[^"]*"';
+		};
+
+		var shellEscapes = {
+			bash:function( arg, idx ) {
+				return toString( arg )
+					.reMatch( segmentRegex( '\\' ) )
+					.map( ( segment ) => {
+						if( !segment.startswith( '"' ) ) {
+							segment = segment.replace( ' ', '\ ', 'all' );
+						}
+						return segment;
+					} )
+					.toList( '' );
+			},
+			cmd:function( arg, idx ) {
+				return toString( arg )
+					.reMatch( segmentRegex() )
+					.map( ( segment ) => {
+						if( !segment.startswith( '"' ) and segment.find( ' ' ) ) {
+							segment = '"#segment#"';
+						}
+						if( segment.endswith( '\"' ) ) {
+							// cmd will pass this literally, so we need to escape it for the underlying Java process
+							segment = segment.left( -2 ) & '\\"';
+						}
+						return segment;
+					} )
+					.toList( '' );
+			},
+			pwsh:function( arg, idx ) {
+				return toString( arg )
+					.reMatch( segmentRegex( '`' ) )
+					.map( ( segment ) => {
+						if( !segment.startswith( '"' ) ) {
+							segment = segment.replace( ' ', '` ', 'all' );
+						}
+						// PowerShell needs the `-` in single `-` args escaped when they contain periods
+						// or it will split the argument at the period
+						if( segment.reFind( '^-(?!-)' ) && segment.find( '.' ) ) {
+							segment = '`' & segment;
+						}
+						return segment;
+					} )
+					.toList( '' );
+			}
+		};
+
+		return shellEscapes[ targetShell ];
+	}
+
+}

--- a/src/cfml/system/services/InterceptorService.cfc
+++ b/src/cfml/system/services/InterceptorService.cfc
@@ -33,7 +33,7 @@ component accessors=true singleton {
 			// Module lifecycle
 			'preModuleLoad','postModuleLoad','preModuleUnLoad','postModuleUnload',
 			// Server lifecycle
-			'preServerStart','onServerStart','onServerInstall','onServerStop','preServerForget','postServerForget',
+			'preServerStart','onServerStart','onServerInstall','onServerCommandLine','onServerStop','preServerForget','postServerForget',
 			// Error handling
 			'onException',
 			// Package lifecycle


### PR DESCRIPTION
This removes all new shell script logic from `ServerService.cfc`, replacing it with an interception point. I chose `onServerCommandLine` but am certainly happy to change it. I also allow for the possibility of the command args being replaced entirely by setting the `args` variable after the interception point. I wasn't sure if you still wanted that or not. For the intercept data I took everything from the previous interception point (`onServerStart`) and added in `commandLineArguments` - I wasn't sure if all of that data needed to be there, but it is there for now.

The interceptor itself is looking for two server props `scriptFile=(cmd|pwsh|bash)` (which is required for it to do anything), and an optional `scriptFilePath=/random/path/to/script.sh` which specifies where to save the script. Absent a file path, it saves the script next to `server.json` (i.e. `serverInfo.serverConfigFile`) with a name taken from the `serverInfo.serverConfigFile` file name.