### PR TITLE
COMMANDBOX-1111 - make createZipFromPath public

### DIFF
--- a/src/cfml/system/endpoints/ForgeBox.cfc
+++ b/src/cfml/system/endpoints/ForgeBox.cfc
@@ -508,7 +508,7 @@ component accessors="true" implements="IEndpointInteractive" {
 		}
 	}
 
-	private function createZipFromPath( required string path ) {
+	function createZipFromPath( required string path ) {
 		if( !packageService.isPackage( arguments.path ) ) {
 			throw(
 				'Sorry but [#arguments.path#] isn''t a package.',


### PR DESCRIPTION
Can we make this a public method so we can call it directly if a customer wants to package up for another storage location?

https://ortussolutions.atlassian.net/browse/COMMANDBOX-1111