### PR TITLE
COMMANDBOX-1112

### DIFF
--- a/src/cfml/system/modules_app/server-commands/commands/server/start.cfc
+++ b/src/cfml/system/modules_app/server-commands/commands/server/start.cfc
@@ -74,6 +74,7 @@ component aliases="start" {
 	 * @minHeapSize			The min heap size in megabytes you would like this server to start with
 	 * @directoryBrowsing 	Enable/Disabled directory browsing, defaults to false
 	 * @JVMArgs 			Additional JVM args to use when starting the server. Use "server status --verbose" to debug
+	 * @runwarJarPath		path to runwar jar (overrides the default runwar location in the ~/.CommandBox/lib/ folder)
 	 * @runwarArgs 			Additional Runwar options to use when starting the server. Use "server status --verbose" to debug
 	 * @saveSettings 		Save start settings in server.json
 	 * @cfengine        	sets the cfml engine type

--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -251,6 +251,9 @@ component accessors="true" singleton {
 		if( !isNull( serverProps.javaHomeDirectory ) ) {
 			serverProps.javaHomeDirectory = fileSystemUtil.resolvePath( serverProps.javaHomeDirectory );
 		}
+		if( !isNull( serverProps.runwarJarPath ) ) {
+			serverProps.runwarJarPath = fileSystemUtil.resolvePath( serverProps.runwarJarPath );
+		}
 
 		if( structKeyExists( serverProps, 'trace' ) && serverProps.trace ) {
 			serverProps.debug = true;

--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -185,6 +185,7 @@ component accessors="true" singleton {
 				'sessionCookieHTTPOnly' : d.app.sessionCookieHTTPOnly ?: false
 			},
 			'runwar' : {
+				'jarPath' : d.runwar.jarPath ?: variables.jarPath,
 				'args' : d.runwar.args ?: '',
 				// Duplicate so onServerStart interceptors don't actually change config settings via reference.
 				'XNIOOptions' : duplicate( d.runwar.XNIOOptions ?: {} ),
@@ -493,6 +494,9 @@ component accessors="true" singleton {
 			    case "javaVersion":
 					serverJSON[ 'JVM' ][ 'javaVersion' ] = serverProps[ prop ];
 			         break;
+				case "runwarJarPath":
+					serverJSON[ 'runwar' ][ 'jarPath' ] = serverProps[ prop ];
+					 break;
 			    case "runwarArgs":
 					serverJSON[ 'runwar' ][ 'args' ] = serverProps[ prop ];
 			         break;
@@ -709,6 +713,9 @@ component accessors="true" singleton {
 
 		// Global defauls are always added on top of whatever is specified by the user or server.json
 		serverInfo.JVMargs			= ( serverProps.JVMargs			?: serverJSON.JVM.args ?: '' ) & ' ' & defaults.JVM.args;
+
+		// Global defauls are always added on top of whatever is specified by the user or server.json
+		serverInfo.runwarJarPath	= serverProps.runwarJarPath		?: serverJSON.runwar.jarPath	?: defaults.runwar.jarPath;
 
 		// Global defauls are always added on top of whatever is specified by the user or server.json
 		serverInfo.runwarArgs		= ( serverProps.runwarArgs		?: serverJSON.runwar.args ?: '' ) & ' ' & defaults.runwar.args;
@@ -1059,8 +1066,8 @@ component accessors="true" singleton {
 		// Add java agent
 		if( len( trim( javaAgent ) ) ) { argTokens.append( javaagent ); }
 
-		args
-			.append( '-jar' ).append( variables.jarPath )
+		 args
+		 	.append( '-jar' ).append( serverInfo.runwarJarPath )
 			.append( '--background=#background#' )
 			.append( '--host' ).append( serverInfo.host )
 			.append( '--stop-port' ).append( serverInfo.stopsocket )


### PR DESCRIPTION
Adds configurable location for runwar.jar when starting servers. I am obviously open to suggestions about naming. I chose `runwar.jarPath` since you have the default location stored in `serverService.cfc` as `variables.jarPath`.