### PR TITLE
Use exec in bash script

### DIFF
--- a/src/cfml/system/modules_app/server-commands/interceptors/serverCommandLine.cfc
+++ b/src/cfml/system/modules_app/server-commands/interceptors/serverCommandLine.cfc
@@ -123,7 +123,8 @@ component {
 			bash: function( arg, idx ) {
 				if( idx == 1 ) {
 					// actual process to run, don't quote this
-					return toString( arg ).replace( ' ', '\ ', 'all' );
+					// add exec so that the java process replaces the shell process
+					return 'exec ' & toString( arg ).replace( ' ', '\ ', 'all' );
 				}
 				// otherwise, just fully quote with _single_ quotes
 				return "'" & toString( arg ).replace( "'", "'\''", "all" ) & "'";


### PR DESCRIPTION
Adding exec allows the java process to replace the shell process, which is important when starting docker containers as it allows java to be pid:1 rather than the shell.