### PR TITLE
Fix env struct map

### DIFF
--- a/src/cfml/system/modules_app/system-commands/commands/run.cfc
+++ b/src/cfml/system/modules_app/system-commands/commands/run.cfc
@@ -78,7 +78,7 @@ component{
             
             // incorporate CommandBox environment variables into the process's env
             var currentEnv = processBuilder.environment();
-            currentEnv.putAll( systemSettings.getAllEnvironmentsFlattened() );
+            currentEnv.putAll( systemSettings.getAllEnvironmentsFlattened().map( (k, v)=>toString(v) ) );
             
             // Special check to remove ConEMU vars which can screw up the sub process if it happens to run cmd, such as opening VSCode.
             if( fileSystemUtil.isWindows() && currentEnv.containsKey( 'ConEmuPID' ) ) {

--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -1308,7 +1308,7 @@ component accessors="true" singleton {
 
         // incorporate CommandBox environment variables into the process's env
         var currentEnv = processBuilder.environment();
-        currentEnv.putAll( systemSettings.getAllEnvironmentsFlattened().map( (e)=>toString(e) ) );
+        currentEnv.putAll( systemSettings.getAllEnvironmentsFlattened().map( (k, v)=>toString(v) ) );
 
         // Special check to remove ConEMU vars which can screw up the sub process if it happens to run cmd, such as opening VSCode.
         if( fileSystemUtil.isWindows() && currentEnv.containsKey( 'ConEmuPID' ) ) {


### PR DESCRIPTION
Since systemSettings.getAllEnvironmentsFlattened() returns a struct, mapping it requires two args, the second of which is the value. As is, the struct values get overwritten with the struct keys.