### PR TITLE
Guard against setting version to patch, minor or major

### DIFF
--- a/src/cfml/system/modules_app/package-commands/commands/package/version.cfc
+++ b/src/cfml/system/modules_app/package-commands/commands/package/version.cfc
@@ -76,6 +76,14 @@ component aliases="bump" {
 		var versionObject = semanticVersion.parseVersion( trim( boxJSON.version ?: '' ) );
 
 		if( len( arguments.version ) ) {
+			
+			if ( !arguments.force && listFind( "patch,minor,major", arguments.version ) ) {
+				print.line("Are you sure you want to set the version to: #arguments.version#?");
+				print.line("    You probably wanted to run: --#arguments.version#");
+			    if ( ask("Do you really want to do this [yes/no]:" ) != "Yes" ) {
+				    return;
+				}
+			}
 
 			// Set a specific version
 			arguments.version = semanticVersion.clean( arguments.version );


### PR DESCRIPTION
I can imagine a hypothetical situation where some developer accidentally ran `bump patch` instead of `bump --patch` and then published a version called `patch` by accident. 

I'm glad I've never done that!