### PR TITLE
Check file permissions in repl command

### DIFF
--- a/src/cfml/system/modules_app/system-commands/commands/repl.cfc
+++ b/src/cfml/system/modules_app/system-commands/commands/repl.cfc
@@ -38,9 +38,15 @@ component {
 		var results  		= "";
 		var executor 		= wirebox.getInstance( "executor" );
 		var newHistory 		= arguments.script ? variables.REPLScriptHistoryFile : variables.REPLTagHistoryFile;
+		var dirInfo 		= "";
 
   	   arguments.directory = resolvePath( arguments.directory );
   	   
+	   dirInfo = getFileInfo( arguments.directory );
+	   if ( !dirInfo.canWrite ) {
+	        error( "Unable to start a repl in this directory because you do not have write permission to it." );
+	   }
+	   
 		// Setup REPL history file
 		shell.setHistory( newHistory );
 		shell.setHighlighter( 'REPL' );


### PR DESCRIPTION
You need to be able to write to the directory (which defaults to the current one) otherwise a permission denied error will occur.