### PR TITLE
Fix failing external '!' commands that end with 'help'

### DIFF
--- a/src/cfml/system/services/CommandService.cfc
+++ b/src/cfml/system/services/CommandService.cfc
@@ -606,7 +606,7 @@ component accessors="true" singleton {
 			// If command ends with "help", switch it around to call the root help command
 			// Ex. "coldbox help" becomes "help coldbox"
 			// Don't do this if we're already in a help command or endless recursion will ensue.
-			if( tokens.len() > 1 && listFindNoCase( helpTokens, tokens.last() ) && !inCommand( 'help' ) ){
+			if( tokens.len() > 1 && listFindNoCase( helpTokens, tokens.last() ) && !tokens[1].startsWith('!') && !inCommand( 'help' ) ){
 				// Move help to the beginning
 				tokens.deleteAt( tokens.len() );
 				tokens.prepend( 'help' );


### PR DESCRIPTION
The sample external command I tested with is:
!docker run --rm -it -e apim_aceeptEULA=YES eaps-docker-coldfusion.bintray.io/apim/apimanager:latest help

I  expected the docker command to execute,  which in this case passes 'help' as a command arg to 'docker run', but instead commandbox executed 'help run' or 'run help' and displayed the help docs for the 'run' commandbox command.

The "fix" is too not  allow commandbox to run 'help' command when using '!' aka external commands. 