### PR TITLE
Add Flash Remoting Mappings

### DIFF
--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -879,7 +879,7 @@ component accessors="true" singleton {
 		if( serverInfo.blockFlashRemoting ) {
 			serverInfo.webRules.append( [ 
 				// These all map to web.xml servlet mappings for ACF
-				"path-prefix( { '/flex2gateway','/flex-internal','/flashservices/gateway','/cfform-internal','/CFFormGateway' } ) -> { set-error( 404 ); done }",
+				"path-prefix( { '/flex2gateway','/flex-internal','/flashservices/gateway','/cfform-internal','/CFFormGateway', '/openamf/gateway', '/messagebroker' } ) -> { set-error( 404 ); done }",
 				// Files used for flash remoting
 				"regex( pattern='\.(mxml|cfswf)$', case-sensitive=false ) -> { set-error( 404 ); done }"				
 			], true );	


### PR DESCRIPTION
These may be used in Lucee Flash Remoting, the following from the default lucee installer (though disabled by default)


        #ProxyPassMatch ^/flex2gateway/(.*)$ http://127.0.0.1:8888/flex2gateway/$1
        #ProxyPassMatch ^/messagebroker/(.*)$ http://127.0.0.1:8888/messagebroker/$1
        #ProxyPassMatch ^/flashservices/gateway(.*)$ http://127.0.0.1:8888/flashservices/gateway$1
        #ProxyPassMatch ^/openamf/gateway/(.*)$ http://127.0.0.1:8888/openamf/gateway/$1