### PR TITLE
add optional flag app.serverHomeDirectoryVersion

### DIFF
--- a/src/cfml/system/services/ServerEngineService.cfc
+++ b/src/cfml/system/services/ServerEngineService.cfc
@@ -194,9 +194,12 @@ component accessors="true" singleton="true" {
 			// Overriding server home which is where the exploded war lives
 			if( len( arguments.serverHomeDirectory ) ) {
 				installDetails.installDir = arguments.serverHomeDirectory;
-			// Default is engine-version folder in base dir
+			} else if ( !arguments.serverInfo.app.serverHomeDirectoryVersion ){
+				// Use engine folder in base dir
+				installDetails.installDir = destination & engineName;
 			} else {
-				installDetails.installDir = destination & engineName & "-" & replace( satisfyingVersion, '+', '.', 'all' );
+				// Default is engine-version folder in base dir
+				installDetails.installDir = destination & engineName & "-" &  replace( satisfyingVersion, '+', '.', 'all' );
 			}
 			installDetails.version = satisfyingVersion;
 

--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -195,6 +195,8 @@ component accessors="true" singleton {
 				'cfengine' : d.app.cfengine ?: '',
 				'restMappings' : d.app.cfengine ?: '',
 				'serverHomeDirectory' : d.app.serverHomeDirectory ?: '',
+				// If serverHomeDirectory isn't defined, by default, the generated serverHomeDirectory directory name includes the specific Engine Version
+				'serverHomeDirectoryVersion' : d.app.serverHomeDirectoryVersion ?: true,
 				'sessionCookieSecure' : d.app.sessionCookieSecure ?: false,
 				'sessionCookieHTTPOnly' : d.app.sessionCookieHTTPOnly ?: false
 			},


### PR DESCRIPTION
defaults to true, i.e. existing behaviour

when set to false and no `serverHomeDirectory` is configured, the generated server home directory will be based only on the engine name, omitting the version number

this means if Lucee releases an update, CommandBox will re-use the existing server home directory,  just like a **traditional** #lucee install, rather than creating a whole new home directory (**280mb a pop**) each time

the first server is with the flag **disabled**, the second is **default** 

![image](https://user-images.githubusercontent.com/426404/113757370-d09ba980-9712-11eb-9e19-bf08e2247bed.png)
