### PR TITLE
Remove improper constructor call

### DIFF
--- a/src/java/cliloader/LoaderCLIMain.java
+++ b/src/java/cliloader/LoaderCLIMain.java
@@ -488,7 +488,6 @@ public class LoaderCLIMain{
 	private static String getJarDir(){
 		String path = new File( LoaderCLIMain.class.getProtectionDomain()
 				.getCodeSource().getLocation().getPath() ).getParent();
-		new java.net.URLDecoder();
 		// Decode things like spaces in folders which will be %20
 		return URLDecoder.decode( path );
 	}


### PR DESCRIPTION
The constructor call on the non-instantiable URLDecoder class appears to be being prevented as of Java 17. Removing it does not affect the code in any way.
(edited for grammar)