### PR TITLE
[CommandDSL] Changed the param called name in init to command

### DIFF
--- a/src/cfml/system/util/CommandDSL.cfc
+++ b/src/cfml/system/util/CommandDSL.cfc
@@ -37,13 +37,13 @@ component accessors=true {
 	 *
 	 * @name.hint I am the command to execute
   	 **/
-	function init( name ) {
+	function init( command ) {
 
-		if( !structKeyExists( arguments, 'name' ) ) {
-			throw( 'Command name not provided' );
+		if( !structKeyExists( arguments, 'command' ) ) {
+			throw( 'Command not provided' );
 		}
 
-		setCommand( arguments.name );
+		setCommand( arguments.command );
 		setPiped( [] );
 		setParams( [] );
 		setFlags( [] );


### PR DESCRIPTION
Changed the param called name in init to reflect what it will accept as a value. command() can accept a full commandstring ie: `rm --recurse --force` or just simply a namespace and/or command name ie: `rm` then chained with flags ie: `.flags('recurse','force')`.