### PR TITLE
Add COMMANDBOX_HOME environment var to server start

### DIFF
--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -1568,6 +1568,11 @@ component accessors="true" singleton {
             }
         }
 
+		// Add COMMANDBOX_HOME env var to the server if not already there
+		if ( !currentEnv.containsKey( 'COMMANDBOX_HOME' ) ) {
+			currentEnv.put( 'COMMANDBOX_HOME', expandPath( '/commandbox-home' ) );
+		}
+
 	    // Conjoin standard error and output for convenience.
 	    processBuilder.redirectErrorStream( true );
 	    // Kick off actual process


### PR DESCRIPTION
There is no easy and reliable way to know the `COMMANDBOX_HOME` from within a server started by `server start`. 

This change will create an environment variable in the new process for the server if the environment var is not already specified.

This would be useful for HackMyCF, but also useful in general. 

Discussed with Brad over slack DM a few weeks ago.