### PR TITLE
Add COMMANDBOX_VERSION env var to server start

### DIFF
--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -1572,6 +1572,12 @@ component accessors="true" singleton {
 		if ( !currentEnv.containsKey( 'COMMANDBOX_HOME' ) ) {
 			currentEnv.put( 'COMMANDBOX_HOME', expandPath( '/commandbox-home' ) );
 		}
+		
+		// Add COMMANDBOX_VERSION env var to the server if not already there
+		if ( !currentEnv.containsKey( 'COMMANDBOX_VERSION' ) ) {
+			currentEnv.put( 'COMMANDBOX_VERSION', shell.getVersion() );
+		}
+		
 
 	    // Conjoin standard error and output for convenience.
 	    processBuilder.redirectErrorStream( true );


### PR DESCRIPTION
This change will allow servers to know what version of commandbox started them.