### PR TITLE
Set the server name when creating new app

### DIFF
--- a/src/cfml/system/modules_app/coldbox-commands/commands/coldbox/create/app.cfc
+++ b/src/cfml/system/modules_app/coldbox-commands/commands/coldbox/create/app.cfc
@@ -136,6 +136,13 @@ component {
 				scripts  = "{}"
 			)
 			.run();
+			
+		//set the server name
+		command( "server set" )
+			.params(
+				name     = arguments.name,
+			)
+			.run();
 	}
 
 	/**


### PR DESCRIPTION
The name is not set by default in the server.json in the app templates, so it will use the current directory as the server name. That might be ok for some, but you can also end up with a bunch of servers named `app` or `wwwroot`, etc. if you create a sub dir in your project for the web root.