### PR TITLE
Add string type to keywords in box schema

### DIFF
--- a/src/cfml/system/config/box.schema.json
+++ b/src/cfml/system/config/box.schema.json
@@ -210,7 +210,10 @@
 		"keywords": {
 			"title": "Keywords",
 			"description": "ForgeBox keywords",
-			"type": "array",
+			"type": [
+				"array",
+				"string"
+			],
 			"items": {
 				"title": "Keyword",
 				"description": "ForgeBox keyword",


### PR DESCRIPTION
I've noticed several packages, including official Ortus ones, use a string list for `keywords`, so I figure that is valid as well.