### PR TITLE
server.schema.json JVM args accepts string array

### DIFF
--- a/src/cfml/system/config/server.schema.json
+++ b/src/cfml/system/config/server.schema.json
@@ -158,7 +158,10 @@
 				"args": {
 					"title": "JVM Arguments",
 					"description": "Ad-hoc JVM args for the server such as -X:name",
-					"type": "string",
+					"type": [
+						"string",
+						"array"
+					],
 					"default": ""
 				},
 				"javaHome": {


### PR DESCRIPTION
JVM.args accepts both string and arrays.

https://commandbox.ortusbooks.com/embedded-server/configuring-your-server/jvm-args#ad-hoc-jvm-args

Updates server.schema.json to accept both types.

https://cswr.github.io/JsonSchema/spec/multiple_types/