### PR TITLE
Correct Spelling on "Resstart" to "Restart"

### DIFF
--- a/src/cfml/system/modules_app/server-commands/commands/server/restart.cfc
+++ b/src/cfml/system/modules_app/server-commands/commands/server/restart.cfc
@@ -1,5 +1,5 @@
 /**
- * Resstart an embedded CFML server.  Run command from the web root of the server or use
+ * Restart an embedded CFML server.  Run command from the web root of the server or use
  * the 'directory' and/or 'name' arguments.
  * .
  * {code:bash}


### PR DESCRIPTION
Spelling correction.