### PR TITLE
🐛 FIX: Warn and show test results when testbox headers are missing

### DIFF
--- a/src/cfml/system/modules_app/testbox-commands/commands/testbox/run.cfc
+++ b/src/cfml/system/modules_app/testbox-commands/commands/testbox/run.cfc
@@ -185,6 +185,9 @@ component {
 				// print Failure report
 				setExitCode( 1 );
 				print.boldRed( " " & results.filecontent );
+			} else {
+				print.yellow( " Missing 'x-testbox' result errors; cannot determine if tests are failing." );
+				print.yellow( " " & results.filecontent );
 			}
 		}
 


### PR DESCRIPTION
If a test errors out in some manner causing TestBox to omit the proper result headers, the `testbox run` command is silent.

This is because the `if()` conditions wrapping the test output all expect one or both `x-testbox-` headers to exist:

```js
if (
	( results.responseheader[ "x-testbox-totalFail" ] ?: 0 ) eq 0 AND
	( results.responseheader[ "x-testbox-totalError" ] ?: 0 ) eq 0
) {
	// print OK report
	print.green( " " & results.filecontent );
} else if ( results.responseheader[ "x-testbox-totalFail" ] gt 0 ) {
	// print Failure report
	setExitCode( 1 );
	print.yellow( " " & results.filecontent );
} else if ( results.responseheader[ "x-testbox-totalError" ] gt 0 ) {
	// print Failure report
	setExitCode( 1 );
	print.boldRed( " " & results.filecontent );
}
```