### PR TITLE
Support setting terminal window title in shell.cfc

### DIFF
--- a/src/cfml/system/Shell.cfc
+++ b/src/cfml/system/Shell.cfc
@@ -140,10 +140,13 @@ component accessors="true" singleton {
 	 * Finish configuring the shell
 	 **/
 	function onDIComplete() {
+		// When the shell first starts, the current working dir doesn't always contain the trailing slash
+		variables.pwd = fileSystem.resolvePath( variables.pwd );
+
 		// Create reader console and setup the default shell Prompt
-		variables.reader 		= readerFactory.getInstance( argumentCollection = variables.initArgs  );
-		variables.shellPrompt 	= print.green( "CommandBox> ");
-		variables.windowTitle 	= "CommandBox";
+		variables.reader = readerFactory.getInstance( argumentCollection = variables.initArgs  );
+		setPrompt();
+		setWindowTitle();
 
 		// Create temp dir & set
 		setTempDir( variables.tempdir );
@@ -156,9 +159,6 @@ component accessors="true" singleton {
 			interceptorName 	= "endpoint-service"
 		);
 		getModuleService().configure();
-
-		// When the shell first starts, the current working dir doesn't always contain the trailing slash
-		variables.pwd = fileSystem.resolvePath( variables.pwd );
 
 		getModuleService().activateAllModules();
 

--- a/src/cfml/system/Shell.cfc
+++ b/src/cfml/system/Shell.cfc
@@ -263,7 +263,15 @@ component accessors="true" singleton {
  	 **/
 	Shell function setWindowTitle( text="" ) {
 		if( !len( arguments.text ) ){
-			variables.windowTitle = "CommandBox:#listLast( getPWD(), "/\" )#";
+			var homeDir = fileSystem.normalizeSlashes( fileSystem.resolvePath( '~' ) );
+			var thisFullpath = fileSystem.normalizeSlashes( getPWD() );
+			var thisPath = thisFullpath.listLast( '\/' ) & '/';
+
+			// Shortcut for home dir
+			if( thisFullpath contains homeDir ) {
+				thisPath = thisFullpath.replaceNoCase( homeDir, '~/' );
+			}
+			variables.windowTitle = "CommandBox: #thisPath#";
 		} else {
 			variables.windowTitle = arguments.text;
 		}

--- a/src/cfml/system/Shell.cfc
+++ b/src/cfml/system/Shell.cfc
@@ -63,6 +63,10 @@ component accessors="true" singleton {
 	*/
 	property name="shellPrompt";
 	/**
+	* The default terminal window title
+	*/
+	property name="windowTitle";
+	/**
 	* This value is either "interactive" meaning the shell stays open waiting for user input
 	* or "command" which means a single command will be run and then the shell will be exiting.
 	* This differentiation may be useful for commands who want to be careful not to leave threads running
@@ -111,6 +115,7 @@ component accessors="true" singleton {
 		variables.pwd 			= "";
 		variables.reader 		= "";
 		variables.shellPrompt 	= "";
+		variables.windowTitle 	= "";
 		variables.userDir 	 	= arguments.userDir;
 		variables.tempDir 		= arguments.tempDir;
 
@@ -138,6 +143,7 @@ component accessors="true" singleton {
 		// Create reader console and setup the default shell Prompt
 		variables.reader 		= readerFactory.getInstance( argumentCollection = variables.initArgs  );
 		variables.shellPrompt 	= print.green( "CommandBox> ");
+		variables.windowTitle 	= "CommandBox";
 
 		// Create temp dir & set
 		setTempDir( variables.tempdir );
@@ -248,6 +254,19 @@ component accessors="true" singleton {
 			variables.shellPrompt = arguments.text;
 		}
 		//variables.reader.setPrompt( variables.shellPrompt );
+		return this;
+	}
+
+	/**
+	 * Sets the window title
+	 * @text.hint window title text to set, if empty we use the default title
+ 	 **/
+	Shell function setWindowTitle( text="" ) {
+		if( !len( arguments.text ) ){
+			variables.windowTitle = "CommandBox:#listLast( getPWD(), "/\" )#";
+		} else {
+			variables.windowTitle = arguments.text;
+		}
 		return this;
 	}
 
@@ -509,6 +528,7 @@ component accessors="true" singleton {
 		request.lastCWD = arguments.directory;
 		// Update prompt to reflect directory change
 		setPrompt();
+		setWindowTitle();
 		return variables.pwd;
 	}
 
@@ -553,7 +573,7 @@ component accessors="true" singleton {
 
 				try {
 
-					var interceptData = { prompt : variables.shellPrompt };
+					var interceptData = { prompt : variables.shellPrompt, windowTitle: variables.windowTitle };
 					getInterceptorService().announceInterception( 'prePrompt', interceptData );
 
 					if( arguments.silent ) {
@@ -576,6 +596,8 @@ component accessors="true" singleton {
 						if( arguments.silent ) {
 							line = variables.reader.readLine( interceptData.prompt, javacast( "char", ' ' ) );
 						} else {
+							// set the window title before reading a line
+							variables.reader.getTerminal().writer().print( chr( 27 ) & ']2;' & interceptData.windowTitle & chr( 7 ) );
 							line = variables.reader.readLine( interceptData.prompt );
 						}
 					}

--- a/src/cfml/system/modules_app/system-commands/commands/run.cfc
+++ b/src/cfml/system/modules_app/system-commands/commands/run.cfc
@@ -192,14 +192,6 @@ component{
 				terminal.resume();
 			}
 
-			// Put the terminal title back on Windows
-			if( fileSystemUtil.isWindows() && nativeShell contains 'cmd' ) {
-				var commandArray = [ nativeShell,'/a','/c', 'Title CommandBox is a ColdFusion (CFML) CLI, Package Manager, Server and REPL' ];
-				createObject( "java", "java.lang.ProcessBuilder" ).init( commandArray )
-					.inheritIO()
-					.start();
-			}
-
 			checkInterrupted();
 		}
 


### PR DESCRIPTION
Hi @bdw429s, this is for your consideration :). I like how my bash shell terminal windows reflect the cwd of the shell in the title (matching the prompt), and I am interested in having CommandBox do the same. 

This PR adds support for setting the terminal window title, right before generating the prompt and reading a line from the terminal. I am not sure I have covered all cases where one might want to set the window title, but setting it before the prompt works well in my testing. Please let me know what you think of this, and if you are interested in pursuing it.

If this is added, I think you could also get rid of the title set/reset you do on Windows after the run command: [run.cfc#L195-L201](https://github.com/Ortus-Solutions/commandbox/blob/development/src/cfml/system/modules_app/system-commands/commands/run.cfc#L195-L201), as it would be replaced at the next prompt anyways.

Also, as a side question, when setting the initial `shellPrompt`, you have:
```
variables.shellPrompt = print.green( "CommandBox> ");
```
whereas from then on the default shell prompt (what you get by calling `setPrompt()`) will reflect the cwd. I copied this with the default title, but I wonder if you would be willing to always include the cwd in the title/prompt, even on initial startup? I know that at least I would prefer that.