### PR TITLE
Update start.cfc (as help shown) to use more modern engine version numbers

### DIFF
--- a/src/cfml/system/modules_app/server-commands/commands/server/start.cfc
+++ b/src/cfml/system/modules_app/server-commands/commands/server/start.cfc
@@ -21,15 +21,17 @@
  * Specify an engine version after an @ sign like you would on package installation.
   * .
  * {code:bash}
- * server start cfengine=railo
  * server start cfengine=adobe
- * server start cfengine=adobe@11.0
+ * server start cfengine=adobe@2023.0
+ * server start cfengine=lucee
+ * server start cfengine=lucee@5.4
+ * server start cfengine=railo
  * {code}
  * .
  * cfengine can also be any valid Endpoint ID that points to a ForgeBox entry, HTTP URL, etc.
  * .
  * {code:bash}
- * server start cfengine=https://downloads.ortussolutions.com/adobe/coldfusion/9.0.2/cf-engine-9.0.2.zip
+ * server start cfengine=https://downloads.ortussolutions.com/adobe/coldfusion/2023.0.0/cf-engine-2023.0.0.zip
  * {code}
  * .
  * You can also start up a local WAR file with the WARPath parameter.


### PR DESCRIPTION
Also added Lucee (since it was not shown, with or without a version number), and rearranged the engines in alpha order.