### PR TITLE
Update JavaService.cfc

### DIFF
--- a/src/cfml/system/services/JavaService.cfc
+++ b/src/cfml/system/services/JavaService.cfc
@@ -150,7 +150,7 @@ component accessors="true" singleton {
 			return 'mac';
 		} else if( fileSystemUtil.isLinux() ) {
 			try {
-				if( fileRead( '/proc/version' ) contains 'alpine' ) {
+				if( fileRead( '/etc/os-release' ) contains 'Alpine' ) {
 					return 'alpine-linux';
 				}
 			} catch( any e ) {


### PR DESCRIPTION
linux not being detected correctly: /proc/version returns 

"Linux version 6.6.32-linuxkit (root@buildkitsandbox) (gcc (Alpine 13.2.1_git20240309) 13.2.1 20240309, GNU ld (GNU Binutils) 2.42) #1 SMP Thu Jun 13 14:13:01 UTC 2024" 

on an Ubuntu docker image. This causes Alpine binaries such as openJDK to be installed which don't work on Ubuntu. Using /etc/os-release seems to be a more reliable indicator of OS.

Tried to test but seems bound to building the docker image as the os decision seems to be persisted.