### PR TITLE
Fix dock icon in Java 21+

### DIFF
--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -1592,10 +1592,14 @@ component accessors="true" singleton {
 			'java.management/sun.management'
 		].reduce( (opens='',o)=>opens &= ' --add-opens=#o#=ALL-UNNAMED' );
 
-		var javaExports = [
+		var javaExportsArray = [
 			'java.desktop/sun.java2d',
 			'java.base/sun.util'
-		].reduce( (exports='',o)=>exports &= ' --add-exports=#o#=ALL-UNNAMED' );
+		];
+		if (variables.fileSystemUtil.isMac()) {
+			javaExportsArray.append('java.desktop/com.apple.eawt');
+		}
+		var javaExports = javaExportsArray.reduce( (exports='',o)=>exports &= ' --add-exports=#o#=ALL-UNNAMED' );
 
 		systemSettings.setSystemSetting( 'JDK_JAVA_OPTIONS', systemSettings.getSystemSetting( 'JDK_JAVA_OPTIONS', javaOpens & ' ' & javaExports )  );
 		systemSettings.setSystemSetting( 'COMMANDBOX_HOME', systemSettings.getSystemSetting( 'COMMANDBOX_HOME', expandPath( '/commandbox-home' ) ) );


### PR DESCRIPTION
Conditionally adds exports for java.desktop/com.apple.eawt if OS is Mac. Otherwise default Java logo is used, and error is logged:

> Error setting dock icon image
>   java.lang.IllegalAccessException: class runwar.Server cannot access class com.apple.eawt.Application (in module java.desktop) because module java.desktop does not export com.apple.eawt to unnamed module
