### PR TITLE
Initial Lock file implementation

### DIFF
--- a/src/cfml/system/modules_app/package-commands/commands/package/install.cfc
+++ b/src/cfml/system/modules_app/package-commands/commands/package/install.cfc
@@ -147,32 +147,12 @@ component aliases="install" {
 		// Make ID an array
 		arguments.IDArray = listToArray( arguments.ID );
 
-		arguments.lockFile = {};
-		arguments.lock = arguments.lock || fileExists( arguments.currentWorkingDirectory & '/box-lock.json' );
-		if ( arguments.lock ) {
-			// ensure lock file exists
-			if ( !fileExists( arguments.currentWorkingDirectory & '/box-lock.json' ) ) {
-				print.greenLine( "No lock file exists, creating one..." ).toConsole();
-				var thisBoxJSON = packageService.readPackageDescriptor( arguments.currentWorkingDirectory );
-				arguments.lockFile = {
-					"name": thisBoxJSON.name,
-					"version": thisBoxJSON.version,
-					"lockVersion": 1,
-					"dependencies": {}
-				};
-			} else {
-				print.greenLine( "Loading box-lock.json..." ).toConsole();
-				arguments.lockFile = deserializeJSON( fileRead( expandPath( arguments.currentWorkingDirectory & '/box-lock.json' ) ) );
-			}
-		}
-
 		// Install this package(s).
 		// Don't pass directory unless you intend to override the box.json of the package being installed
 
 		interceptorService.announceInterception( 'preInstallAll', { installArgs=arguments } );
 
 		try {
-
 			// One or more IDs
 			if( arguments.IDArray.len() ) {
 				for( var thisID in arguments.IDArray ){
@@ -191,11 +171,6 @@ component aliases="install" {
 			error( e.message, e.detail );
 		} catch( EndpointNotFound var e ) {
 			error( e.message, e.detail );
-		}
-
-		if ( !arguments.lockFile.isEmpty() ) {
-			JSONService.writeJSONFile( arguments.currentWorkingDirectory & '/box-lock.json', arguments.lockFile );
-			print.greenLine( "box-lock.json written to disk." ).toConsole();
 		}
 
 		interceptorService.announceInterception( 'postInstallAll', { installArgs=arguments } );

--- a/src/cfml/system/modules_app/package-commands/commands/package/install.cfc
+++ b/src/cfml/system/modules_app/package-commands/commands/package/install.cfc
@@ -94,8 +94,9 @@ component aliases="install" {
 	property name="entries";
 
 	// DI
-	property name="packageService"	inject="PackageService";
-	property name="endpointService"	inject="endpointService";
+	property name='JSONService'			inject='JSONService';
+	property name="packageService"	    inject="PackageService";
+	property name="endpointService"	    inject="endpointService";
 	property name='interceptorService'	inject='interceptorService';
 
 	/**
@@ -110,6 +111,7 @@ component aliases="install" {
 	* @verbose.hint Output much more verbose information about the package installation
 	* @force.hint Force dependencies to be installed whether they already exist or not
 	* @system.hint Install this package into the global CommandBox module's folder
+	* @lock.hint Flag to lock the version in the lock file
 	**/
 	function run(
 		string ID='',
@@ -119,7 +121,8 @@ component aliases="install" {
 		boolean production,
 		boolean verbose=false,
 		boolean force=false,
-		boolean system=false
+		boolean system=false,
+		boolean lock=false
 	){
 
 		// Don't default the dir param since we need to differentiate whether the user actually
@@ -144,6 +147,24 @@ component aliases="install" {
 		// Make ID an array
 		arguments.IDArray = listToArray( arguments.ID );
 
+		arguments.lockFile = {};
+		arguments.lock = arguments.lock || fileExists( arguments.currentWorkingDirectory & '/box-lock.json' );
+		if ( arguments.lock ) {
+			// ensure lock file exists
+			if ( !fileExists( arguments.currentWorkingDirectory & '/box-lock.json' ) ) {
+				print.greenLine( "No lock file exists, creating one..." ).toConsole();
+				var thisBoxJSON = packageService.readPackageDescriptor( arguments.currentWorkingDirectory );
+				arguments.lockFile = {
+					"name": thisBoxJSON.name,
+					"version": thisBoxJSON.version,
+					"lockVersion": 1,
+					"dependencies": {}
+				};
+			} else {
+				print.greenLine( "Loading box-lock.json..." ).toConsole();
+				arguments.lockFile = deserializeJSON( fileRead( expandPath( arguments.currentWorkingDirectory & '/box-lock.json' ) ) );
+			}
+		}
 
 		// Install this package(s).
 		// Don't pass directory unless you intend to override the box.json of the package being installed
@@ -172,9 +193,12 @@ component aliases="install" {
 			error( e.message, e.detail );
 		}
 
+		if ( !arguments.lockFile.isEmpty() ) {
+			JSONService.writeJSONFile( arguments.currentWorkingDirectory & '/box-lock.json', arguments.lockFile );
+			print.greenLine( "box-lock.json written to disk." ).toConsole();
+		}
 
 		interceptorService.announceInterception( 'postInstallAll', { installArgs=arguments } );
-
 	}
 
 	// Auto-complete list of IDs

--- a/src/cfml/system/modules_app/package-commands/commands/package/uninstall.cfc
+++ b/src/cfml/system/modules_app/package-commands/commands/package/uninstall.cfc
@@ -64,11 +64,6 @@ component aliases="uninstall" {
 			arguments.currentWorkingDirectory = getCWD();
 		}
 
-		arguments.lockFile = {};
-		if ( fileExists( arguments.currentWorkingDirectory & '/box-lock.json' ) ) {
-			arguments.lockFile = deserializeJSON( fileRead( expandPath( arguments.currentWorkingDirectory & '/box-lock.json' ) ) );
-		}
-
 		// Convert slug to array
 		arguments.slug = listToArray( arguments.slug );
 		// iterate and uninstall.
@@ -78,8 +73,6 @@ component aliases="uninstall" {
 			// Don't pass directory unless you intend to override the box.json of the package being uninstalled
 			packageService.uninstallPackage( argumentCollection = arguments );
 		}
-
-		JSONService.writeJSONFile( arguments.currentWorkingDirectory & '/box-lock.json', arguments.lockFile );
 	}
 
 	// Auto-complete list of slugs

--- a/src/cfml/system/modules_app/package-commands/commands/package/uninstall.cfc
+++ b/src/cfml/system/modules_app/package-commands/commands/package/uninstall.cfc
@@ -20,6 +20,7 @@
 component aliases="uninstall" {
 
 	// DI
+	property name='JSONService'	    inject='JSONService';
 	property name="packageService" 	inject="PackageService";
 
 	/**
@@ -63,6 +64,11 @@ component aliases="uninstall" {
 			arguments.currentWorkingDirectory = getCWD();
 		}
 
+		arguments.lockFile = {};
+		if ( fileExists( arguments.currentWorkingDirectory & '/box-lock.json' ) ) {
+			arguments.lockFile = deserializeJSON( fileRead( expandPath( arguments.currentWorkingDirectory & '/box-lock.json' ) ) );
+		}
+
 		// Convert slug to array
 		arguments.slug = listToArray( arguments.slug );
 		// iterate and uninstall.
@@ -72,6 +78,8 @@ component aliases="uninstall" {
 			// Don't pass directory unless you intend to override the box.json of the package being uninstalled
 			packageService.uninstallPackage( argumentCollection = arguments );
 		}
+
+		JSONService.writeJSONFile( arguments.currentWorkingDirectory & '/box-lock.json', arguments.lockFile );
 	}
 
 	// Auto-complete list of slugs

--- a/src/cfml/system/services/PackageService.cfc
+++ b/src/cfml/system/services/PackageService.cfc
@@ -175,7 +175,7 @@ component accessors="true" singleton {
 				}
 				var requestedVersionSemver = endpointData.endpoint.parseVersion( arguments.ID );
 			} else {
-				var requestedVersionSemver = version;
+				var requestedVersionSemver = nullValue();
 			}
 
 			var tmpPath = endpointData.endpoint.resolvePackage( endpointData.package, arguments.currentWorkingDirectory, arguments.verbose );
@@ -196,6 +196,10 @@ component accessors="true" singleton {
 				var packageType = 'project';
 				var packageName = endpointData.endpoint.getDefaultName( endpointData.package );
 				var version = '1.0.0';
+			}
+
+			if ( isNull( requestedVersionSemver ) ) {
+				requestedVersionSemver = version;
 			}
 
 			// If the dependency struct in box.json has a name, use it.  This is mostly for

--- a/src/cfml/system/services/PackageService.cfc
+++ b/src/cfml/system/services/PackageService.cfc
@@ -31,7 +31,6 @@ component accessors="true" singleton {
 	property name='serverService'		inject='serverService';
 	property name='moduleService'		inject='moduleService';
 
-
 	/**
 	* Constructor
 	*/
@@ -85,16 +84,42 @@ component accessors="true" singleton {
 		boolean force=false,
 		string packagePathRequestingInstallation = arguments.currentWorkingDirectory,
 		string defaultName='',
+		boolean lock=false,
 		struct lockFile={}
 	){
 		// Java service registers itself as an interceptor on creation so I need to force the provider to create the service before installing anything.
 		javaService.$get();
 
-		var lockFilePackagesToNotSaveVersions = {};
-
 		var shellWillReload = false;
-		var job = wirebox.getInstance( 'interactiveJob' );
 		interceptorService.announceInterception( 'preInstall', { installArgs=arguments, packagePathRequestingInstallation=packagePathRequestingInstallation } );
+
+		var lockFilePackagesToNotSaveVersions = {};
+		arguments.lock = arguments.lock || fileExists( arguments.currentWorkingDirectory & '/box-lock.json' );
+		var shouldSaveLockFile = false;
+		if ( arguments.lock && arguments.lockFile.isEmpty() ) {
+			var loadLockFileJob = wirebox.getInstance( 'interactiveJob' );
+			loadLockFileJob.start( "Loading lock file..." );
+			if ( arguments.verbose ) {
+				loadLockFileJob.setDumpLog( arguments.verbose );
+			}
+			if ( !fileExists( arguments.currentWorkingDirectory & '/box-lock.json' ) ) {
+				loadLockFileJob.addLog( "No lock file exists, creating one..." );
+				var thisBoxJSON = packageService.readPackageDescriptor( arguments.currentWorkingDirectory );
+				arguments.lockFile = {
+					"name": thisBoxJSON.name,
+					"version": thisBoxJSON.version,
+					"lockVersion": 1,
+					"dependencies": {}
+				};
+			} else {
+				loadLockFileJob.addLog( "Loading box-lock.json..." );
+				arguments.lockFile = deserializeJSON( fileRead( expandPath( arguments.currentWorkingDirectory & '/box-lock.json' ) ) );
+			}
+			loadLockFileJob.complete( arguments.verbose );
+			shouldSaveLockFile = true;
+		}
+
+		var job = wirebox.getInstance( 'interactiveJob' );
 
 		// If there is a package to install, install it
 		if( len( arguments.ID ) ) {
@@ -123,28 +148,34 @@ component accessors="true" singleton {
 				}
 			}
 
-			if ( !arguments.lockFile.isEmpty() && endpointData.endpointName == 'forgebox' ) {
-				var slug = endpointData.endpoint.parseSlug( endpointData.package );
-				if ( arguments.lockFile.dependencies.keyExists( slug ) ) {
-					var lockedDependency = arguments.lockFile.dependencies[ slug ];
-					var requestedVersion = endpointData.endpoint.parseVersion( endpointData.package );
-					if ( arguments.force ) {
-						arguments.lockFile.dependencies.delete( slug );
-						job.addLog( "Ignoring lock file version [#lockedDependency.version#] for [#slug#] due to `force` flag." );
-						arguments.save = true; // turn on save when forcing an update of a locked version
-					} else if ( semanticVersion.satisfies( lockedDependency.version, requestedVersion ) ) {
-						// our lock file version satisfies the requested version range, so use the locked version
-						lockFilePackagesToNotSaveVersions[ slug ] = true;
-						endpointData.package = slug & '@' & lockedDependency.version;
-						job.addLog( "Lock file version [#lockedDependency.version#] satisfies requested version range [#requestedVersion#] for [#slug#]. Using locked version." );
-					} else {
-						// the version requested is not satisfied by the lock file
-						// so update the lock file to the requested version
-						// we do this by deleting the entry from the lock file.
-						arguments.lockFile.dependencies.delete( slug );
-						job.addLog( "Lock file version [#lockedDependency.version#] does NOT satisfy requested version range [#requestedVersion#] for [#slug#]. Updating to requested version and re-locking." );
+			// TODO: consider making this part of the interface so other endpoint types can also report back
+			// if their installation ID contains a semantic version range
+			if( isInstanceOf(endpointData.endpoint, 'forgebox') ) {
+				if ( !arguments.lockFile.isEmpty() ) {
+					var slug = endpointData.endpoint.parseSlug( endpointData.package );
+					if ( arguments.lockFile.dependencies.keyExists( slug ) ) {
+						var lockedDependency = arguments.lockFile.dependencies[ slug ];
+						var requestedVersion = endpointData.endpoint.parseVersion( endpointData.package );
+						if ( arguments.force ) {
+							arguments.lockFile.dependencies.delete( slug );
+							job.addLog( "Ignoring lock file version [#lockedDependency.version#] for [#slug#] due to `force` flag." );
+						} else if ( semanticVersion.satisfies( lockedDependency.version, requestedVersion ) ) {
+							// our lock file version satisfies the requested version range, so use the locked version
+							lockFilePackagesToNotSaveVersions[ slug ] = true;
+							endpointData.package = slug & '@' & lockedDependency.version;
+							job.addLog( "Lock file version [#lockedDependency.version#] satisfies requested version range [#requestedVersion#] for [#slug#]. Using locked version." );
+						} else {
+							// the version requested is not satisfied by the lock file
+							// so update the lock file to the requested version
+							// we do this by deleting the entry from the lock file.
+							arguments.lockFile.dependencies.delete( slug );
+							job.addLog( "Lock file version [#lockedDependency.version#] does NOT satisfy requested version range [#requestedVersion#] for [#slug#]. Updating to requested version and re-locking." );
+						}
 					}
 				}
+				var requestedVersionSemver = endpointData.endpoint.parseVersion( arguments.ID );
+			} else {
+				var requestedVersionSemver = version;
 			}
 
 			var tmpPath = endpointData.endpoint.resolvePackage( endpointData.package, arguments.currentWorkingDirectory, arguments.verbose );
@@ -165,14 +196,6 @@ component accessors="true" singleton {
 				var packageType = 'project';
 				var packageName = endpointData.endpoint.getDefaultName( endpointData.package );
 				var version = '1.0.0';
-			}
-
-			// TODO: consider making this part of the interface so other endpoint types can also report back
-			// if their installation ID contains a semantic version range
-			if( isInstanceOf(endpointData.endpoint, 'forgebox') ) {
-				var requestedVersionSemver = endpointData.endpoint.parseVersion( arguments.ID );
-			} else {
-				var requestedVersionSemver = version;
 			}
 
 			// If the dependency struct in box.json has a name, use it.  This is mostly for
@@ -477,6 +500,8 @@ component accessors="true" singleton {
 
 			// Assert: At this point, all paths are finalized and we are ready to install.
 
+			updateLockedDependencies( arguments.lockFile, packageName, installedVersion, job );
+
 			// Should we save this as a dependency. Save the install even though the package may already be there
 			if( ( arguments.save || arguments.saveDev ) && !lockFilePackagesToNotSaveVersions.keyExists( slug ) ) {
 				// Add it!
@@ -488,7 +513,7 @@ component accessors="true" singleton {
 				// we only update the lock file if we were saving
 				if (
 					!arguments.lockFile.isEmpty() &&
-					endpointData.endpointName == 'forgebox' &&
+					isInstanceOf( endpointData.endpoint, 'forgebox' ) &&
 					!arguments.lockFile.dependencies.keyExists( packageName )
 				) {
 					arguments.lockFile.dependencies[ packageName ] = {
@@ -714,6 +739,13 @@ component accessors="true" singleton {
 
 		interceptorService.announceInterception( 'postInstall', { installArgs=arguments, installDirectory=installDirectory, system=shellWillReload } );
 		job.complete( verbose );
+
+		if ( shouldSaveLockFile ) {
+			JSONService.writeJSONFile( arguments.currentWorkingDirectory & '/box-lock.json', arguments.lockFile );
+			var saveLockFileJob = wirebox.getInstance( 'InteractiveJob' );
+			saveLockFileJob.start( 'Saving box-lock.json file to disk' );
+			saveLockFileJob.complete();
+		}
 
 		return true;
 	}
@@ -1474,4 +1506,25 @@ component accessors="true" singleton {
 		}
 		return version;
 	}
+
+	private void function updateLockedDependencies(
+		required struct lockSlice,
+		required string packageName,
+		required any newVersion,
+		required job
+	) {
+		if ( !arguments.lockSlice.keyExists( "dependencies" ) || !isStruct( arguments.lockSlice.dependencies ) ) {
+			return;
+		}
+
+		if ( arguments.lockSlice.dependencies.keyExists( arguments.packageName ) ) {
+			arguments.lockSlice.dependencies[ arguments.packageName ].version = arguments.newVersion;
+			job.addLog( "Updated locked version for [#arguments.packageName#] to [#arguments.newVersion#]." );
+		}
+
+		for ( var depName in arguments.lockSlice.dependencies ) {
+			updateLockedDependencies( arguments.lockSlice.dependencies[ depName ], arguments.packageName, arguments.newVersion, job );
+		}
+	}
+
 }

--- a/src/cfml/system/services/PackageService.cfc
+++ b/src/cfml/system/services/PackageService.cfc
@@ -70,23 +70,27 @@ component accessors="true" singleton {
 	* @verbose If set, it will produce much more verbose information about the package installation
 	* @force When set to true, it will force dependencies to be installed whether they already exist or not
 	* @packagePathRequestingInstallation If installing smart dependencies packages (like ColdBox modules) that are capable of being nested, this is our current level
+	* @lock Flag to lock the version in the lock file
 	*
 	* @returns True if no errors encountered, false if things went boom.
 	**/
-	boolean function installPackage(
-			required string ID,
-			string directory,
-			boolean save=false,
-			boolean saveDev=false,
-			boolean production,
-			string currentWorkingDirectory=shell.pwd(),
-			boolean verbose=false,
-			boolean force=false,
-			string packagePathRequestingInstallation = arguments.currentWorkingDirectory,
-			string defaultName=''
+	any function installPackage(
+		required string ID,
+		string directory,
+		boolean save=false,
+		boolean saveDev=false,
+		boolean production,
+		string currentWorkingDirectory=shell.pwd(),
+		boolean verbose=false,
+		boolean force=false,
+		string packagePathRequestingInstallation = arguments.currentWorkingDirectory,
+		string defaultName='',
+		struct lockFile={}
 	){
 		// Java service registers itself as an interceptor on creation so I need to force the provider to create the service before installing anything.
 		javaService.$get();
+
+		var lockFilePackagesToNotSaveVersions = {};
 
 		var shellWillReload = false;
 		var job = wirebox.getInstance( 'interactiveJob' );
@@ -99,7 +103,6 @@ component accessors="true" singleton {
 			arguments.production = arguments.production ?: true;
 
 			var endpointData = endpointService.resolveEndpoint( arguments.ID, arguments.packagePathRequestingInstallation );
-
 			job.start(  'Installing package [#endpointData.ID#]', ( shell.getTermHeight() < 20 ? 1 : 5 ) );
 
 			if( verbose ) {
@@ -119,6 +122,31 @@ component accessors="true" singleton {
 					endpointData.package &= "@#existingVersion#";
 				}
 			}
+
+			if ( !arguments.lockFile.isEmpty() && endpointData.endpointName == 'forgebox' ) {
+				var slug = endpointData.endpoint.parseSlug( endpointData.package );
+				if ( arguments.lockFile.dependencies.keyExists( slug ) ) {
+					var lockedDependency = arguments.lockFile.dependencies[ slug ];
+					var requestedVersion = endpointData.endpoint.parseVersion( endpointData.package );
+					if ( arguments.force ) {
+						arguments.lockFile.dependencies.delete( slug );
+						job.addLog( "Ignoring lock file version [#lockedDependency.version#] for [#slug#] due to `force` flag." );
+						arguments.save = true; // turn on save when forcing an update of a locked version
+					} else if ( semanticVersion.satisfies( lockedDependency.version, requestedVersion ) ) {
+						// our lock file version satisfies the requested version range, so use the locked version
+						lockFilePackagesToNotSaveVersions[ slug ] = true;
+						endpointData.package = slug & '@' & lockedDependency.version;
+						job.addLog( "Lock file version [#lockedDependency.version#] satisfies requested version range [#requestedVersion#] for [#slug#]. Using locked version." );
+					} else {
+						// the version requested is not satisfied by the lock file
+						// so update the lock file to the requested version
+						// we do this by deleting the entry from the lock file.
+						arguments.lockFile.dependencies.delete( slug );
+						job.addLog( "Lock file version [#lockedDependency.version#] does NOT satisfy requested version range [#requestedVersion#] for [#slug#]. Updating to requested version and re-locking." );
+					}
+				}
+			}
+
 			var tmpPath = endpointData.endpoint.resolvePackage( endpointData.package, arguments.currentWorkingDirectory, arguments.verbose );
 
 			// Support box.json in the root OR in a subfolder (NPM-style!)
@@ -129,6 +157,7 @@ component accessors="true" singleton {
 				var boxJSON = readPackageDescriptor( tmpPath );
 				var packageType = boxJSON.type;
 				var packageName = boxJSON.slug;
+				var installedVersion = boxJSON.version;
 				var version = updateBoxJSONDependency ? boxJSON.version : existingVersion;
 			} else {
 				job.addErrorLog( "box.json is missing so this isn't really a package! I'll install it anyway, but I'm not happy about it" );
@@ -138,7 +167,7 @@ component accessors="true" singleton {
 				var version = '1.0.0';
 			}
 
-			// Todo, consider making this part of the interface so other endpoint types can also report back
+			// TODO: consider making this part of the interface so other endpoint types can also report back
 			// if their installation ID contains a semantic version range
 			if( isInstanceOf(endpointData.endpoint, 'forgebox') ) {
 				var requestedVersionSemver = endpointData.endpoint.parseVersion( arguments.ID );
@@ -304,7 +333,7 @@ component accessors="true" singleton {
 			interceptorService.announceInterception( 'onInstall', interceptData );
 			// Make sure these get set back into their original variables in case the interceptor changed them.
 			installDirectory = interceptData.installDirectory;
-			ignorePatterns = interceptData.ignorePatterns;			
+			ignorePatterns = interceptData.ignorePatterns;
 			arguments.currentWorkingDirectory = interceptData.currentWorkingDirectory;
 			arguments.packagePathRequestingInstallation = interceptData.packagePathRequestingInstallation;
 			tmpPath = interceptData.artifactPath;
@@ -449,11 +478,26 @@ component accessors="true" singleton {
 			// Assert: At this point, all paths are finalized and we are ready to install.
 
 			// Should we save this as a dependency. Save the install even though the package may already be there
-			if( ( arguments.save || arguments.saveDev ) ) {
+			if( ( arguments.save || arguments.saveDev ) && !lockFilePackagesToNotSaveVersions.keyExists( slug ) ) {
 				// Add it!
 				if( addDependency( packagePathRequestingInstallation, packageName, version, installDirectory, artifactDescriptor.createPackageDirectory,  arguments.saveDev, endpointData ) ) {
 					// Tell the user...
 					job.addLog( "#packagePathRequestingInstallation#/box.json updated with #( arguments.saveDev ? 'dev ': '' )#dependency." );
+				}
+
+				// we only update the lock file if we were saving
+				if (
+					!arguments.lockFile.isEmpty() &&
+					endpointData.endpointName == 'forgebox' &&
+					!arguments.lockFile.dependencies.keyExists( packageName )
+				) {
+					arguments.lockFile.dependencies[ packageName ] = {
+						"version": installedVersion,
+						"dev": arguments.saveDev,
+						"dependencies": {}
+					};
+					// write out updated lock file
+					job.addLog( "box-lock.json updated with locked version [#installedVersion#] for [#slug#]." );
 				}
 			}
 
@@ -651,7 +695,8 @@ component accessors="true" singleton {
 				production = true,
 				currentWorkingDirectory = arguments.currentWorkingDirectory, // Original dir
 				packagePathRequestingInstallation = installDirectory, // directory for smart dependencies to use
-				defaultName = dependency
+				defaultName = dependency,
+				lockFile = arguments.lockFile.isEmpty() ? {} : ( isNull( packageName ) || !arguments.lockFile.dependencies.keyExists( packageName ) ? arguments.lockFile : arguments.lockFile.dependencies[ packageName ] )
 			};
 
 			// Recursively install them
@@ -717,12 +762,13 @@ component accessors="true" singleton {
 	* @currentWorkingDirectory Root of the application (used for finding box.json)
 	**/
 	function uninstallPackage(
-			required string ID,
-			string directory,
-			boolean save=false,
-			required string currentWorkingDirectory,
-			string packagePathRequestingUninstallation = arguments.currentWorkingDirectory,
-			boolean verbose = false
+		required string ID,
+		string directory,
+		boolean save=false,
+		required string currentWorkingDirectory,
+		string packagePathRequestingUninstallation = arguments.currentWorkingDirectory,
+		boolean verbose = false,
+		struct lockFile = {}
 	){
 
 		var job = wirebox.getInstance( 'interactiveJob' );
@@ -848,6 +894,11 @@ component accessors="true" singleton {
 			removeDependency( currentWorkingDirectory, packageName );
 			// Tell the user...
 			job.addLog( "Dependency removed from box.json." );
+
+			if ( arguments.lockFile.dependencies.keyExists( packageName ) ) {
+				arguments.lockFile.dependencies.delete( packageName );
+				job.addLog( "box-lock.json updated to remove locked version for [#packageName#]." );
+			}
 		}
 
 		interceptorService.announceInterception( 'postUninstall', { uninstallArgs=arguments, system=systemModule } );
@@ -1078,7 +1129,6 @@ component accessors="true" singleton {
 			systemSettings.expandDeepSystemSettings( results );
 		}
 		return results;
-
 	}
 
 	/**

--- a/src/cfml/system/services/PackageService.cfc
+++ b/src/cfml/system/services/PackageService.cfc
@@ -931,7 +931,7 @@ component accessors="true" singleton {
 			// Tell the user...
 			job.addLog( "Dependency removed from box.json." );
 
-			if ( arguments.lockFile.dependencies.keyExists( packageName ) ) {
+			if ( !arguments.lockFile.isEmpty() && arguments.lockFile.keyExists( "dependencies" ) && arguments.lockFile.dependencies.keyExists( packageName ) ) {
 				arguments.lockFile.dependencies.delete( packageName );
 				job.addLog( "box-lock.json updated to remove locked version for [#packageName#]." );
 			}

--- a/src/cfml/system/services/PackageService.cfc
+++ b/src/cfml/system/services/PackageService.cfc
@@ -522,7 +522,7 @@ component accessors="true" singleton {
 						"dependencies": {}
 					};
 					// write out updated lock file
-					job.addLog( "box-lock.json updated with locked version [#installedVersion#] for [#slug#]." );
+					job.addLog( "box-lock.json updated with locked version [#installedVersion#] for [#packageName#]." );
 				}
 			}
 

--- a/src/cfml/system/services/PackageService.cfc
+++ b/src/cfml/system/services/PackageService.cfc
@@ -1511,7 +1511,7 @@ component accessors="true" singleton {
 		required struct lockSlice,
 		required string packageName,
 		required any newVersion,
-		required job
+		required any job
 	) {
 		if ( !arguments.lockSlice.keyExists( "dependencies" ) || !isStruct( arguments.lockSlice.dependencies ) ) {
 			return;

--- a/src/cfml/system/services/PackageService.cfc
+++ b/src/cfml/system/services/PackageService.cfc
@@ -73,7 +73,7 @@ component accessors="true" singleton {
 	*
 	* @returns True if no errors encountered, false if things went boom.
 	**/
-	any function installPackage(
+	boolean function installPackage(
 		required string ID,
 		string directory,
 		boolean save=false,

--- a/src/cfml/system/services/PackageService.cfc
+++ b/src/cfml/system/services/PackageService.cfc
@@ -503,7 +503,7 @@ component accessors="true" singleton {
 			updateLockedDependencies( arguments.lockFile, packageName, installedVersion, job );
 
 			// Should we save this as a dependency. Save the install even though the package may already be there
-			if( ( arguments.save || arguments.saveDev ) && !lockFilePackagesToNotSaveVersions.keyExists( slug ) ) {
+			if( ( arguments.save || arguments.saveDev ) && !lockFilePackagesToNotSaveVersions.keyExists( packageName ) ) {
 				// Add it!
 				if( addDependency( packagePathRequestingInstallation, packageName, version, installDirectory, artifactDescriptor.createPackageDirectory,  arguments.saveDev, endpointData ) ) {
 					// Tell the user...


### PR DESCRIPTION
- It creates a lock file when the `--lock` flag is passed to `install`.
- It maintains locked versions across `install`, `uninstall`, and `update` as long as a `box-lock.json` file is detected.
- It does nothing to systems not using a lock file.
- It adds the latest version matching the installed semver range when locking.
- It installs the locked version if it matches the semver range of the package.
- It installs the latest version matching the semver range if the locked version does not match the semver range and updates the locked version.
- It updates the locked version on `--force` installs
- It does nothing with the locked version if `--!save` and `--!saveDev`
- It updates the locked versions on updated packages from `update`.