### PR TITLE
Correct watch command example shown in help

### DIFF
--- a/src/cfml/system/modules_app/system-commands/commands/watch.cfc
+++ b/src/cfml/system/modules_app/system-commands/commands/watch.cfc
@@ -2,7 +2,7 @@
  * Watch the files in a directory and run a custom command of your choice
  *
  * {code}
- * watch *.json "echo 'config file updated!'"
+ * watch paths=*.json command="echo 'config file updated!'"
  * {code}
  *
  * The following environment variables will be available to your command


### PR DESCRIPTION
Fix command syntax for first example offered in javadocs comment, as it no longer works as presented (and the comments are what's shown for the help in the CLI).

The current example (using positional arg) would have stopped working after [the 2021 commit](https://github.com/Ortus-Solutions/commandbox/commit/fbdfd9b441b6f3d4f57156694e481d9b45b67657
) which added @excludePath as a new arg, inserting as the second one positionally before the "command" arg. 

Of course, the example could be changed instead to insert an empty second arg: 

`watch *.json "" "echo 'config file updated!'"`

But I suspect that would be deemed clumsy, even if less verbose. 