### PR TITLE
fix: restMappings default reads d.app.restMappings, not d.app.cfengine

### DIFF
--- a/src/cfml/system/services/ServerService.cfc
+++ b/src/cfml/system/services/ServerService.cfc
@@ -261,7 +261,7 @@ component accessors="true" singleton {
 				'standalone' : d.app.standalone ?: false,
 				'WARPath' : d.app.WARPath ?: '',
 				'cfengine' : d.app.cfengine ?: '',
-				'restMappings' : d.app.cfengine ?: '',
+				'restMappings' : d.app.restMappings ?: '',
 				'serverHomeDirectory' : d.app.serverHomeDirectory ?: '',
 				'singleServerHome' : d.app.singleServerHome ?: false,
 				'sessionCookieSecure' : d.app.sessionCookieSecure ?: false,


### PR DESCRIPTION
## Summary

One-line copy-paste typo at [src/cfml/system/services/ServerService.cfc:264](https://github.com/Ortus-Solutions/commandbox/blob/development/src/cfml/system/services/ServerService.cfc#L264):

```cfml
'restMappings' : d.app.cfengine ?: '',
```

Reads `d.app.cfengine` for the `restMappings` default — should be `d.app.restMappings`.

## Impact

For users who set a global default cfengine via `config set server.defaults.app.cfengine=...`, the cfengine string (e.g. `lucee@7`, `adobe@2025`) cascades into `restMappings` and gets passed to runwar as a URL pattern. runwar then:

- Sets `servletRestEnable=true` (because the value is non-empty)
- Splits `"lucee@7"` as a single bogus URL pattern
- Strips the real `/rest/*` web.xml mapping (because `ignoreWebXmlRestMappings && servletRestEnable`)
- Replaces it with a `lucee@7` URL pattern that nothing matches

Result: REST endpoints 404 silently. Affects both Lucee and ACF deployments via CommandBox.

Users without a global default cfengine are unaffected — the fallback is `''` either way.

## Test plan

- [ ] Set `config set server.defaults.app.cfengine=lucee@7`, start a server without explicit `app.restMappings`, confirm REST endpoints work as expected.
- [ ] Without the global default set, behaviour is unchanged.