### PR TITLE
Add human-in-the-loop confirmation for risky package install scripts

### DIFF
--- a/src/cfml/system/modules_app/package-commands/commands/package/install.cfc
+++ b/src/cfml/system/modules_app/package-commands/commands/package/install.cfc
@@ -124,16 +124,8 @@ component aliases="install" {
 		boolean force=false,
 		boolean system=false,
 		boolean lock=false,
-		boolean trustScripts=false
+		boolean trustScripts=configService.getSetting( 'scripts.trustInstallScripts', false )
 	){
-
-		// When asked to trust scripts, set the trust env var into this command's environment so the
-		// install-lifecycle script confirmation is bypassed (works in interactive and non-interactive
-		// shells). The setting lives in this command's environment frame and is discarded once the
-		// install completes, so it does not leak to later commands.
-		if( arguments.trustScripts ) {
-			systemSettings.setSystemSetting( 'COMMANDBOX_TRUST_INSTALL_SCRIPTS', 'true' );
-		}
 
 		// Don't default the dir param since we need to differentiate whether the user actually
 		// specifically typed in a param or not since it overrides the package's box.json install dir.

--- a/src/cfml/system/modules_app/package-commands/commands/package/install.cfc
+++ b/src/cfml/system/modules_app/package-commands/commands/package/install.cfc
@@ -112,6 +112,7 @@ component aliases="install" {
 	* @force.hint Force dependencies to be installed whether they already exist or not
 	* @system.hint Install this package into the global CommandBox module's folder
 	* @lock.hint Flag to lock the version in the lock file
+	* @trustScripts.hint Automatically allow the installed package(s) install-lifecycle scripts to run without a confirmation prompt
 	**/
 	function run(
 		string ID='',
@@ -122,8 +123,17 @@ component aliases="install" {
 		boolean verbose=false,
 		boolean force=false,
 		boolean system=false,
-		boolean lock=false
+		boolean lock=false,
+		boolean trustScripts=false
 	){
+
+		// When asked to trust scripts, set the trust env var into this command's environment so the
+		// install-lifecycle script confirmation is bypassed (works in interactive and non-interactive
+		// shells). The setting lives in this command's environment frame and is discarded once the
+		// install completes, so it does not leak to later commands.
+		if( arguments.trustScripts ) {
+			systemSettings.setSystemSetting( 'COMMANDBOX_TRUST_INSTALL_SCRIPTS', 'true' );
+		}
 
 		// Don't default the dir param since we need to differentiate whether the user actually
 		// specifically typed in a param or not since it overrides the package's box.json install dir.

--- a/src/cfml/system/modules_app/package-commands/interceptors/PackageScripts.cfc
+++ b/src/cfml/system/modules_app/package-commands/interceptors/PackageScripts.cfc
@@ -78,7 +78,8 @@ component {
 	function processScripts( required string interceptionPoint, string directory=shell.pwd(), interceptData={} ) {
 		inScript=true;
 		try {
-			packageService.runScript( arguments.interceptionPoint, arguments.directory, true, interceptData );
+			// automatic=true so install-lifecycle scripts can be gated behind a confirmation prompt
+			packageService.runScript( arguments.interceptionPoint, arguments.directory, true, interceptData, true );
 		} finally {
 			inScript=false;
 		}

--- a/src/cfml/system/services/ConfigService.cfc
+++ b/src/cfml/system/services/ConfigService.cfc
@@ -96,7 +96,10 @@ component accessors="true" singleton {
 			'configAutoSync.endpoint',
 			'configAutoSync.overwrite',
 			// Task Runners
-			'taskCaching'
+			'taskCaching',
+			// Package/server script security
+			'scripts.confirmInstallScripts',
+			'scripts.trustInstallScriptsNonInteractive'
 		]);
 
 		setConfigFilePath( '/commandbox-home/CommandBox.json' );

--- a/src/cfml/system/services/ConfigService.cfc
+++ b/src/cfml/system/services/ConfigService.cfc
@@ -97,9 +97,8 @@ component accessors="true" singleton {
 			'configAutoSync.overwrite',
 			// Task Runners
 			'taskCaching',
-			// Package/server script security
-			'scripts.confirmInstallScripts',
-			'scripts.trustInstallScriptsNonInteractive'
+			// Package install script security
+			'scripts.trustInstallScripts'
 		]);
 
 		setConfigFilePath( '/commandbox-home/CommandBox.json' );

--- a/src/cfml/system/services/PackageService.cfc
+++ b/src/cfml/system/services/PackageService.cfc
@@ -86,7 +86,8 @@ component accessors="true" singleton {
 		string packagePathRequestingInstallation = arguments.currentWorkingDirectory,
 		string defaultName='',
 		boolean lock=false,
-		struct lockFile={}
+		struct lockFile={},
+		boolean trustScripts=configService.getSetting( 'scripts.trustInstallScripts', false )
 	){
 		// Java service registers itself as an interceptor on creation so I need to force the provider to create the service before installing anything.
 		javaService.$get();
@@ -729,6 +730,7 @@ component accessors="true" singleton {
 				currentWorkingDirectory = arguments.currentWorkingDirectory, // Original dir
 				packagePathRequestingInstallation = installDirectory, // directory for smart dependencies to use
 				defaultName = dependency,
+				trustScripts = arguments.trustScripts,
 				lockFile = arguments.lockFile.isEmpty() ? {} : ( isNull( packageName ) || !arguments.lockFile.dependencies.keyExists( packageName ) ? arguments.lockFile : arguments.lockFile.dependencies[ packageName ] )
 			};
 
@@ -1455,7 +1457,7 @@ component accessors="true" singleton {
 			if( scriptNameCommands.len()
 				&& arguments.automatic
 				&& isRiskyInstallScript( arguments.scriptName )
-				&& !confirmRiskyScript( arguments.scriptName, arguments.directory, scriptNameCommands ) ) {
+				&& !confirmScriptExecution( arguments.scriptName, arguments.directory, scriptNameCommands, arguments.interceptData ) ) {
 				consoleLogger.warn( 'Skipped package script [#arguments.scriptName#] — not approved.' );
 			} else if( scriptNameCommands.len() ) {
 				consoleLogger.debug( '.' );
@@ -1510,25 +1512,29 @@ component accessors="true" singleton {
 	* Ask the user (human-in-the-loop) whether a potentially risky, automatically-fired install script
 	* should be allowed to run.  Returns true to run the script, false to skip it.
 	*
-	* Behavior:
-	*  - If the master switch "scripts.confirmInstallScripts" is false, scripts run without prompting.
-	*  - In a non-interactive shell (CI / no TTY) the script is denied unless explicitly trusted via the
-	*    config setting "scripts.trustInstallScriptsNonInteractive" or the environment variable
-	*    "COMMANDBOX_TRUST_INSTALL_SCRIPTS".
+	* Trust is granted per-install via the "trustScripts" arg (carried in interceptData.installArgs),
+	* which itself defaults to the "scripts.trustInstallScripts" config setting.  The
+	* "box_config_scripts_trustInstallScripts" environment variable overrides that config setting
+	* automatically via ConfigService, so we never read env vars directly here.
+	*
+	* Behavior when not trusted:
+	*  - In a non-interactive shell (CI / no TTY) the script is denied since we can't prompt.
 	*  - Otherwise the exact commands are shown and the user is asked a yes/no question.
 	*
 	* @scriptName Name of the package script / interception point
 	* @directory The package root the script will run in
 	* @commands An array of the command strings that will be executed
+	* @interceptData The interception data for this event (carries installArgs.trustScripts when present)
 	*/
-	private boolean function confirmRiskyScript( required string scriptName, required string directory, required array commands ) {
-		// Master switch — when disabled, preserve the original auto-run behavior.
-		if( !configService.getSetting( 'scripts.confirmInstallScripts', true ) ) {
+	private boolean function confirmScriptExecution( required string scriptName, required string directory, required array commands, struct interceptData={} ) {
+		// Trust may be granted for this install via the trustScripts arg; otherwise fall back to the
+		// config setting (which the box_config_scripts_trustInstallScripts env var overrides for free).
+		var trusted = arguments.interceptData.installArgs.trustScripts ?: configService.getSetting( 'scripts.trustInstallScripts', false );
+		if( trusted ) {
 			return true;
 		}
 
-		// Show the user exactly what is about to run so they can make an informed decision
-		// (also leaves an audit trail in CI logs when trust is granted).
+		// Show the user exactly what is about to run so they can make an informed decision.
 		consoleLogger.warn( '.' );
 		consoleLogger.warn( 'SECURITY: The package script [#arguments.scriptName#] wants to automatically run the following command(s):' );
 		consoleLogger.warn( '  Package location: #arguments.directory#' );
@@ -1536,30 +1542,13 @@ component accessors="true" singleton {
 			consoleLogger.error( '  > ' & thisCommand );
 		}
 
-		// Explicit trust escape hatch (e.g. "install --trustScripts" or CI) bypasses the prompt in any shell.
-		if( isTruthy( systemSettings.getSystemSetting( 'COMMANDBOX_TRUST_INSTALL_SCRIPTS', false ) ) ) {
-			return true;
-		}
-
-		// Non-interactive shells (CI, piped input, no TTY) can't answer a prompt.  Deny by default
-		// unless the user has explicitly opted in via config setting.
+		// Non-interactive shells (CI, piped input, no TTY) can't answer a prompt, so deny.
 		if( !shell.isTerminalInteractive() ) {
-			if( configService.getSetting( 'scripts.trustInstallScriptsNonInteractive', false ) ) {
-				return true;
-			}
-			consoleLogger.warn( 'Refusing to auto-run install script in a non-interactive shell. Set config setting [scripts.trustInstallScriptsNonInteractive=true], environment variable [COMMANDBOX_TRUST_INSTALL_SCRIPTS=true], or pass [--trustScripts] to allow.' );
+			consoleLogger.warn( 'Refusing to auto-run install script in a non-interactive shell. Set config setting [scripts.trustInstallScripts=true] or pass [--trustScripts] to allow.' );
 			return false;
 		}
 
 		return shell.confirm( 'Do you want to allow this script to run? [y/n]' );
-	}
-
-	/**
-	* Loose truthiness check for a setting/env var value that may be a boolean, "true"/"false", "1"/"0", etc.
-	* @value The value to evaluate
-	*/
-	private boolean function isTruthy( required any value ) {
-		return isBoolean( arguments.value ) && arguments.value;
 	}
 
 	/**

--- a/src/cfml/system/services/PackageService.cfc
+++ b/src/cfml/system/services/PackageService.cfc
@@ -30,6 +30,7 @@ component accessors="true" singleton {
 	property name='tempDir' 			inject='tempDir@constants';
 	property name='serverService'		inject='serverService';
 	property name='moduleService'		inject='moduleService';
+	property name='configService'		inject='ConfigService';
 
 	/**
 	* Constructor
@@ -1426,8 +1427,9 @@ component accessors="true" singleton {
 	* @directory The package root
 	* @ignoreMissing Set true to ignore missing package scripts, false to throw an exception
 	* @interceptData An optional struct of data if this package script is being fired as part of an interceptor announcement.  Will be loaded into env vars
+	* @automatic Set true when this script is being fired automatically by an interceptor (not explicitly invoked by the user).  Used to gate potentially risky install-lifecycle scripts behind a confirmation prompt.
 	*/
-	function runScript( required string scriptName, string directory=shell.pwd(), boolean ignoreMissing=true, interceptData={} ) {
+	function runScript( required string scriptName, string directory=shell.pwd(), boolean ignoreMissing=true, interceptData={}, boolean automatic=false ) {
 		// Read the box.json from this package (if it exists)
 		var boxJSON = readPackageDescriptorRaw( arguments.directory );
 		// If there is a scripts object with a matching key for this interceptor....
@@ -1447,7 +1449,15 @@ component accessors="true" singleton {
 			if( isSimpleValue( scriptNameCommands ) ) {
 				scriptNameCommands = [ scriptNameCommands ];
 			}
-			if( scriptNameCommands.len() ) {
+			// Gate automatically-fired install-lifecycle scripts behind a human-in-the-loop confirmation.
+			// This is the classic supply-chain risk: installing a third party package can silently run
+			// arbitrary commands via its install scripts.  Explicit "run-script" invocations are not gated.
+			if( scriptNameCommands.len()
+				&& arguments.automatic
+				&& isRiskyInstallScript( arguments.scriptName )
+				&& !confirmRiskyScript( arguments.scriptName, arguments.directory, scriptNameCommands ) ) {
+				consoleLogger.warn( 'Skipped package script [#arguments.scriptName#] — not approved.' );
+			} else if( scriptNameCommands.len() ) {
 				consoleLogger.debug( '.' );
 				consoleLogger.warn( 'Running package script [#arguments.scriptName#].' );
 				for( var scriptNameCommand in scriptNameCommands ) {
@@ -1481,6 +1491,75 @@ component accessors="true" singleton {
 		} else if( !arguments.ignoreMissing ) {
 			consoleLogger.error( 'The script [#arguments.scriptName#] does not exist in this package.' );
 		}
+	}
+
+	/**
+	* Is this script name one of the install-lifecycle interception points that runs code originating
+	* from a package being added or removed?  These are the points worth confirming with a human since
+	* they can run arbitrary commands defined by a (potentially untrusted) third party package.
+	* The recursive pre.../post... wrapper names that runScript derives (e.g. prepostInstall) are
+	* intentionally excluded so a single event prompts at most once.
+	* @scriptName Name of the package script / interception point
+	*/
+	private boolean function isRiskyInstallScript( required string scriptName ) {
+		var riskyEvents = 'preInstall,preInstallAll,onInstall,postInstall,postInstallAll,preUninstall,postUninstall';
+		return riskyEvents.listFindNoCase( arguments.scriptName ) > 0;
+	}
+
+	/**
+	* Ask the user (human-in-the-loop) whether a potentially risky, automatically-fired install script
+	* should be allowed to run.  Returns true to run the script, false to skip it.
+	*
+	* Behavior:
+	*  - If the master switch "scripts.confirmInstallScripts" is false, scripts run without prompting.
+	*  - In a non-interactive shell (CI / no TTY) the script is denied unless explicitly trusted via the
+	*    config setting "scripts.trustInstallScriptsNonInteractive" or the environment variable
+	*    "COMMANDBOX_TRUST_INSTALL_SCRIPTS".
+	*  - Otherwise the exact commands are shown and the user is asked a yes/no question.
+	*
+	* @scriptName Name of the package script / interception point
+	* @directory The package root the script will run in
+	* @commands An array of the command strings that will be executed
+	*/
+	private boolean function confirmRiskyScript( required string scriptName, required string directory, required array commands ) {
+		// Master switch — when disabled, preserve the original auto-run behavior.
+		if( !configService.getSetting( 'scripts.confirmInstallScripts', true ) ) {
+			return true;
+		}
+
+		// Show the user exactly what is about to run so they can make an informed decision
+		// (also leaves an audit trail in CI logs when trust is granted).
+		consoleLogger.warn( '.' );
+		consoleLogger.warn( 'SECURITY: The package script [#arguments.scriptName#] wants to automatically run the following command(s):' );
+		consoleLogger.warn( '  Package location: #arguments.directory#' );
+		for( var thisCommand in arguments.commands ) {
+			consoleLogger.error( '  > ' & thisCommand );
+		}
+
+		// Explicit trust escape hatch (e.g. "install --trustScripts" or CI) bypasses the prompt in any shell.
+		if( isTruthy( systemSettings.getSystemSetting( 'COMMANDBOX_TRUST_INSTALL_SCRIPTS', false ) ) ) {
+			return true;
+		}
+
+		// Non-interactive shells (CI, piped input, no TTY) can't answer a prompt.  Deny by default
+		// unless the user has explicitly opted in via config setting.
+		if( !shell.isTerminalInteractive() ) {
+			if( configService.getSetting( 'scripts.trustInstallScriptsNonInteractive', false ) ) {
+				return true;
+			}
+			consoleLogger.warn( 'Refusing to auto-run install script in a non-interactive shell. Set config setting [scripts.trustInstallScriptsNonInteractive=true], environment variable [COMMANDBOX_TRUST_INSTALL_SCRIPTS=true], or pass [--trustScripts] to allow.' );
+			return false;
+		}
+
+		return shell.confirm( 'Do you want to allow this script to run? [y/n]' );
+	}
+
+	/**
+	* Loose truthiness check for a setting/env var value that may be a boolean, "true"/"false", "1"/"0", etc.
+	* @value The value to evaluate
+	*/
+	private boolean function isTruthy( required any value ) {
+		return isBoolean( arguments.value ) && arguments.value;
 	}
 
 	/**


### PR DESCRIPTION
# Description

A `box.json` `scripts` block can be keyed to install-lifecycle interception points (`preInstall`, `onInstall`, `postInstall`, …). The `PackageScripts` interceptor fires these **automatically** and `PackageService.runScript()` runs each entry through `shell.callCommand()` — arbitrary CommandBox/native commands. This is the classic supply-chain risk: installing a third‑party package from ForgeBox/git can silently execute attacker-controlled commands with no user awareness.

This PR adds a **yes/no human-in-the-loop confirmation** before CommandBox auto-runs an install-lifecycle script, printing the exact commands first so the user can decline untrusted code.

**How it works**
- `PackageService.runScript()` gains an `automatic` flag. Only interceptor-driven runs (`PackageScripts.cfc`) set it, so explicit `run-script` invocations are **never** prompted (the user asked for those).
- Gating is limited to install/uninstall lifecycle events (`preInstall`, `preInstallAll`, `onInstall`, `postInstall`, `postInstallAll`, `preUninstall`, `postUninstall`). Benign high-frequency points (`preCommand`, `prePrompt`, `onCLIStart`, …) are untouched, so there is no prompt spam.
- A single config setting **`scripts.trustInstallScripts`** (default `false`) governs trust:
  - `false` → interactive shell prompts yes/no; non-interactive shell (CI / no TTY) denies since it can't prompt.
  - `true` → scripts run without prompting.
- Trust can be granted three ways, all funnelling through the one setting:
  - `config set scripts.trustInstallScripts=true`
  - `box_config_scripts_trustInstallScripts=true` env var (uses the existing config-override mechanism in `ConfigService.loadOverrides()` — no bespoke env-var handling in code)
  - `install --trustScripts` (per-invocation; the command arg **defaults to the config setting** and propagates through recursive dependency installs via `interceptData.installArgs.trustScripts`)

A non-boolean config value is intentionally **not** silently coerced — it errors out rather than being treated as `false`.

**Reused building blocks:** `shell.confirm()`, `shell.isTerminalInteractive()`, `configService.getSetting()` + the `box_config_*` override in `ConfigService.loadOverrides()`.

**Files changed**
- `services/PackageService.cfc` — `automatic` param, gate, `isRiskyInstallScript()` / `confirmScriptExecution()` helpers, `trustScripts` threaded through `installPackage()`.
- `package-commands/interceptors/PackageScripts.cfc` — pass `automatic=true`.
- `package-commands/commands/package/install.cfc` — `--trustScripts` flag defaulting to the config setting.
- `services/ConfigService.cfc` — register `scripts.trustInstallScripts`.

No new dependencies.

> Once approved, the same change is prepared for the `boxlang` branch on `claude/boxlang-security-prompts-s20wjh-boxlang`.

## Jira Issues

_No Jira issue created yet — please advise if one should be linked before merge._

## Type of change

- [x] New Feature
- [x] This change requires a documentation update (new `scripts.trustInstallScripts` config setting)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

> Transparency: I was unable to run the CommandBox CLI/test suite in this environment (JRE present but no bootstrapped CLI), so the feature has **not** been exercised at runtime and no automated tests are attached yet. The logic and every caller of `runScript()` were reviewed by hand. Happy to add TestBox coverage and docs before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)